### PR TITLE
docs(ba:propose): brainstorm and plan for shipping command

### DIFF
--- a/docs/brainstorms/2026-05-19-ba-propose-shipping-skill-brainstorm.md
+++ b/docs/brainstorms/2026-05-19-ba-propose-shipping-skill-brainstorm.md
@@ -1,0 +1,258 @@
+---
+date: 2026-05-19
+topic: ba-propose-shipping-skill
+status: approved
+triage_level: full
+tags: [skill, dev-workflow, commit, pull-request, merge-request, body-composition, design-it-twice]
+---
+
+# `ba:propose` — Shipping Skill (commit + push + open PR/MR)
+
+## What We're Building
+
+A new `ba:propose` command for the `dev-workflow` plugin that handles commit, push, and open-PR/MR with a good commit message. It belongs to a new **Git workflow** category in CLAUDE.md (mirroring CE/Every's vocabulary), distinct from the existing Research / Planning / Execution / Quality / Knowledge buckets. Replaces Bruno's local `mr` skill (`~/.claude/skills/mr/SKILL.md`) — specifically dropping its rigid `Impact` / `Motivation` / `Implementation Notes` three-heading template in favor of size-tiered scaffolds that select from Michael Lynch's menu of optional sections. Modeled on EveryInc's `ce-commit-push-pr` skill (mode dispatch, branch routing, `--body-file` safety, preview-then-apply), informed by Lynch's *How to Write Useful Commit Messages*, but scoped tighter than CE: no automated evidence capture, no autonomous shipping framing.
+
+The command lives at `commands/ba/propose.md`, under the `ba:` prefix alongside `ba:execute` / `ba:review` / `ba:compound`. A single command detects the remote host (`github.com` / `gitlab.com` / GHES / self-hosted GL) and dispatches to `gh` or `glab` accordingly — shared composition logic, thin platform-adapter for branch routing, push, and create-PR/MR commands. Evidence handling accepts user-supplied screenshot URLs and Loom links only; the CE `ce-demo-reel` automated-capture flow is explicitly out (dev-server cost, flag-gated UI states, brittle selectors are the wrong trade-off for Bruno's day-to-day workflow). Linear MCP integration is optional — when an issue ID is supplied or detected from the branch name, motivation pulls from MCP; otherwise it derives from the diff and recent commits.
+
+## Why This Approach
+
+Three vocabularies for body composition were on the table: CE's adaptive size tiers (typo/small/medium/large/perf), Lynch's menu of ~16 optional sections, and the `mr` skill's fixed three-heading template (being dropped). The initial lean was "size-tiered scaffolds that select from Lynch's menu" — but at least one credible alternative was needed before locking, because the choice shapes every downstream interface.
+
+Phase 2 dispatched three `interface-design-generator` agents in parallel under Ousterhout-flavored constraints — deepest-module (A), common-case (B), info-hiding (C). The contrast: A makes composition a pure function with materialized inputs; B optimizes for the 80% medium-PR case with a public `overrides` taxonomy as escape hatch; C goes maximum-future-proof with composition owning its own diff/issue/solutions ports.
+
+The locked design is a **hybrid of A and C**: A's pure-function composition (orchestrator materializes inputs, composition reaches out to nothing) with C's opaque value-object inputs (`IssueContext.raw: Mapping[str, Any]`, generic `PreservedBlock`, generic `EvidenceItem`). Rationale: pure composition stays deterministic, testable, and preview-symmetric; opaque inputs absorb Linear MCP schema drift without coupling the seam to it; B's public `overrides` record was rejected as a YAGNI trap because preview-then-apply already covers ad-hoc overrides (just edit the preview).
+
+## Key Decisions
+
+- **Command name: `ba:propose`** — frames the act as "proposing changes for review" (echoes Lynch's first purpose: help the code reviewer). Other names considered: `ba:ship` (rejected — too broad), `ba:submit`, `ba:pr`, `ba:open`.
+- **New "Git workflow" command category** in CLAUDE.md / README, mirroring CE/Every's vocabulary. `ba:propose` belongs here rather than under Execution (which is plan-authoritative) or Quality (which is review-only). Plan must update CLAUDE.md `## Conventions` and README accordingly. Leaves room for future siblings if any ever arise.
+- **Single command, host-detected dispatch** for GitHub (`gh`) and GitLab (`glab`). Composition logic is shared in a references file; branch routing, push, and create-PR/MR commands diverge in a thin platform-adapter layer.
+- **Linear MCP integration is optional** — when an issue ID is supplied or detected from the branch name, motivation pulls from MCP; when absent, motivation derives from the diff and recent commits. Linear is never a hard dependency.
+- **`docs/solutions/` auto-detection** — scan entries touched on the current branch since the last merge to `origin/HEAD`; offer to splice their summaries as a "What I learned" section per Lynch's menu. User confirms before splicing. This is the natural bridge to `/ba:compound`.
+- **Commit body and PR description aligned by default** — same markdown feeds `git commit -F <file>` and `gh pr create --body-file <file>`. No `--diverge` flag; see *2026-05-19 Addendum — `--diverge` dropped* at the bottom of this brainstorm for the post-capture reconsideration. The common-case default plus the preview's Edit affordance cover ad-hoc divergence without a knob.
+- **Body composition uses size-tiered scaffolds selecting from the Lynch menu** — but this vocabulary is hidden behind the composition seam (see `## Locked Design`). Future authors can swap to pure-Lynch, pure-CE, or a continuous-score scheme without changing the call site.
+- **Evidence handling accepts user-supplied URLs only.** Two answers to the evidence prompt: "Use existing evidence" (paste URL / markdown embed → splice `## Demo`) or "Skip." No automated capture.
+- **Carry over from `mr` skill verbatim:** Linear MCP motivation gathering (optional), Cursor BugBot block preservation (`<!-- CURSOR_SUMMARY --> … <!-- /CURSOR_SUMMARY -->`), Lynch's "title = effect, not mechanism" worked-examples table.
+- **Drop from `mr` skill:** fixed three-heading template, hardcoded `time-off` scope, 50-char title cap, GitLab-only orientation.
+- **Carry over from CE verbatim:** mode dispatch (description-only / description-update / full workflow), four-way branch-state decision tree, file-level commit splitting (no `git add -A`/`git add .`), `--body-file` discipline with temp file + quoted-sentinel heredoc, preview-then-apply with title/length/lead-sentence summary, `fix:` vs `feat:` ambiguity rule, GitHub `#`-list-prefix gotcha.
+- **Drop from CE:** the Compound Engineering badge, the `ce-demo-reel` automated-capture flow entirely.
+
+## Locked Design
+
+**Source:** Hybrid: A's pure-function composition + C's opaque value-object inputs
+
+### Interface
+
+```python
+def compose_body(inputs: CompositionInputs) -> ComposedBody: ...
+
+@dataclass(frozen=True)
+class CompositionInputs:
+    diff: Diff                              # opaque; carries range + file stats + hunks
+    branch: BranchMetadata                  # name, base ref, author, last-merge SHA
+    issue_context: IssueContext | None      # opaque (from C — absorbs MCP schema drift)
+    solutions: tuple[SolutionEntry, ...]    # opaque; auto-detected docs/solutions/ entries
+    preserved_blocks: tuple[PreservedBlock, ...]   # opaque (kind, raw_markdown)
+    evidence: tuple[EvidenceItem, ...]      # opaque; user-supplied URLs / embeds
+
+@dataclass(frozen=True)
+class IssueContext:
+    raw: Mapping[str, Any]                  # whatever MCP returned — composition reads what it needs
+
+@dataclass(frozen=True)
+class ComposedBody:
+    title: str                              # effect-phrased, ≤72 chars, no trailing period
+    body: str                               # final markdown — feeds both commit and PR/MR
+```
+
+**Invariants the seam guarantees:**
+
+- `body` never restates the diff verbatim — CE's "the diff is already visible" principle is enforced inside.
+- `title` is effect-phrased (Lynch); mechanism-only titles are rewritten inside before return.
+- Preserved blocks appear exactly once, byte-identical to input, in the position composition chose.
+- Section order follows Lynch's priority order (descriptive title → impact → motivation → breaking changes → …).
+- Empty inputs (no Linear, no solutions, no preserved blocks, tiny diff) still produce a valid minimal body — no exceptions, no `None`.
+- Stateless; deterministic given identical inputs.
+
+Errors collapse to `CompositionInputError` (raised only when the diff itself is unreadable or empty). All other "missing" inputs are normal cases absorbed silently.
+
+### Usage example
+
+```python
+# Inside commands/ba/propose.md orchestrator, after gathering inputs:
+result = compose_body(CompositionInputs(
+    diff=collected_diff,
+    branch=branch_meta,
+    issue_context=linear_ctx,             # or None
+    solutions=detected_solutions,          # tuple, possibly empty
+    preserved_blocks=detected_blocks,      # BugBot, Demo, Screenshots
+    evidence=evidence_items,               # user-supplied URLs/embeds
+))
+
+commit_message = f"{result.title}\n\n{result.body}"
+pr_body        = result.body               # same body; --diverge handled upstream
+preview(result.title, result.body)
+```
+
+That is the full caller surface. No tier flag, no section list, no template selector, no ordering hint.
+
+### What's hidden behind the seam
+
+- **Size-tier decision** — typo / small / medium / large / perf computed inside from diff stats; tier never named at call site.
+- **Section vocabulary choice** — CE tiers, Lynch menu, or hybrid is an internal choice. Swappable later with zero caller change.
+- **Section selection rules** — which optional Lynch sections appear (Motivation, Alternatives, Risk, Rollout, Testing notes, Screenshots, What I learned, Searchable artifacts, Dependency justifications, …) decided from inputs.
+- **Section ordering** — Lynch's priority order enforced internally.
+- **Splice positions for preserved blocks** — where `<!-- CURSOR_SUMMARY -->`, `## Demo`, `## Screenshots` land relative to generated sections.
+- **Title rewriting policy** — "effect, not mechanism" applied inside.
+- **Diff-restatement suppression** — file-list pruning, hunk-summarization thresholds.
+- **Linear-issue rendering** — whether the Linear context becomes a "Context" section, a one-line lede reference, or is dropped entirely for typo-tier changes.
+- **Solutions-linkage rendering** — whether `docs/solutions/` entries become a "What I learned" section, inline links, or are suppressed at small tier.
+- **GitHub vs GitLab markdown dialect quirks** — heading levels, autolink avoidance for `#`-prefixed list items, etc.
+
+### Internal sketch — current tier→section mapping (seam-hidden, swappable)
+
+This is the first implementation's mapping from CE-derived tiers to Lynch's 16-item menu. It is **explicitly seam-hidden** — listed here so the plan and reviewers have a concrete starting point, not as a frozen contract. A future author can rewrite this table, add a tier (e.g., "migration"), or replace the tier system entirely with a continuous score, all without changing the orchestrator call site.
+
+| Tier | Default Lynch sections | Typical shape |
+|---|---|---|
+| **typo** | #1 (title) | 1 line. No body. |
+| **small** | #1, #2 (impact), conditionally #3 (motivation) if non-obvious | Title + 1–3 sentences. No headers. |
+| **medium** | #1, #2, #3, #7 (cross-refs), conditionally #9 (testing instr), #14 (screenshots), #11 (learnings if `docs/solutions/` hits) | Title + narrative + 1–2 H2 sub-sections. |
+| **large** | #1, #2, #3, #4 (breaking if any), #6 (dep justifications if any), #7, #8 (bug summaries), #9, #10 (testing limits), #11, #12 (alternatives), #14 | Title + narrative + 3–5 H2 design-decision callouts + test summary. ~100 lines, cap ~150. |
+| **perf** | #1, #2, #3, #14 (before/after table as visual aid) | Title + before/after table + narrative. |
+
+Lynch section numbers reference `docs/research/2026-05-17-shipping-skill-source-material-research.md` Source 4 ("Menu of sections — NOT a fixed template").
+
+After tier selection, a second-pass filter drops any default section whose source-of-content is missing:
+
+- No Linear issue context → drop the "Motivation from issue" sub-section (or derive from diff instead — see Linear MCP integration decision).
+- No `docs/solutions/` entries on the current branch → drop #11.
+- No detected breaking change in the diff → drop #4.
+- No lockfile / dependency-manifest changes → drop #6.
+- No user-supplied evidence → drop #14.
+
+Worked example (same change, three tiers) — single-row regression "Prevent duplicate session tokens during simultaneous sign-ups":
+
+- **small** — title + a single sentence explaining the race + `Fixes #1234`.
+- **medium** — title + narrative paragraph + `## What changed` + `## Testing` + `Fixes #1234`.
+- **large** — title + narrative + `## Alternatives considered` + `## What I learned` (auto-pulled from `docs/solutions/`) + `## Testing limitations` + `Fixes #1234`.
+
+### Dependency strategy
+
+Pure construction. Composition receives every dependency's *result* through `CompositionInputs` and reaches out to nothing itself — no MCP calls, no `gh`/`glab` calls, no filesystem reads, no git invocations. The orchestrator (`commands/ba/propose.md`) is responsible for fetching the Linear payload via MCP, running git diff, scanning `docs/solutions/` for branch-touched entries, extracting preserved blocks from any existing PR/MR description, and gathering user-supplied evidence URLs. This keeps the seam deep (composition owns every editorial decision) without making composition own I/O — which is the side of the line most likely to churn (MCP schema changes, `gh` vs `glab` divergence, Linear API shape).
+
+Every value crossing the seam is deliberately schema-light: `IssueContext.raw` is `Mapping[str, Any]`, `PreservedBlock` and `EvidenceItem` are generic record types. Composition decides what fields to read from each opaque payload. Linear API drift, MCP schema changes, or a future migration to a different issue tracker land in orchestrator-side adapters — never in composition.
+
+Internally, composition may split into private helpers (tier classifier, section selector, splicer, title rewriter), but none are exported and none are injectable from the caller. Tests substitute inputs, not collaborators.
+
+### Trade-offs
+
+- **High leverage:** orchestrator stays trivial — gather inputs, call `compose_body`, preview, apply. All editorial judgment lives in one place, behind one call.
+- **High leverage:** vocabulary lock-in deferred — the size-tiered-scaffolds-selecting-from-Lynch-menu approach ships as the first implementation; switching to pure-Lynch or pure-CE later costs nothing outward.
+- **High leverage:** preview/apply symmetry is free — because composition is pure and returns the final string, the preview flow is "show `result.body`, then write it" with no risk of drift between preview and apply.
+- **High leverage:** Linear/MCP schema drift absorbed by opaque inputs — a typed `LinearIssue` would have required coordinated changes every time MCP added a field.
+- **Thin leverage:** no fine-grained overrides — forcing a specific section ("always include Demo") requires widening the input record (additive but dilutes the "one input record, all decisions inside" purity). Escape hatch in the meantime: edit the preview.
+- **Thin leverage:** section-choice debugging requires reading composition source — no diagnostic field exposed. Mitigation deferred: a `ComposedBody.trace` field can be added later if observability becomes a real pain point.
+
+This design is **locked** at brainstorm capture per the standing synthesis-lock Discipline Rule (`docs/brainstorms/2026-05-02-ousterhout-principles-roadmap-brainstorm.md` `### Concrete rules`). Plan and execute may refine this design within the bounds of the lock; they may not re-add elements from the rejected designs below.
+
+## Rejected Designs
+
+### Design B — Common case (rejected)
+
+- **Interface summary:** Three required fields (`diff`, `branch`, `preserved?`) cover ~80% of PRs; composition fetches Linear and scans `docs/solutions/` itself via injected clients; public `overrides` record exposes `tier`, `sections`, `issue`, `learnings` as escape hatches; returns `tier` and `sectionsUsed` for preview UI observability.
+- **Why rejected:** The public `overrides` taxonomy locks tier and section vocabulary at the seam — it *will* drift as the menu evolves, forcing coordinated changes at every call site. Composition owning Linear / `docs/solutions/` I/O via injected clients pushes infrastructure concerns into the editorial module. B's `sectionsUsed` observability hook is a fair point but can be added to the hybrid as a `ComposedBody.trace` field later if it proves needed — capturing it now would over-fit to a need that hasn't materialized.
+
+### Design C — Info hiding (rejected as-pure; partially incorporated)
+
+- **Interface summary:** Composition receives raw signals only (`diff_ref_range`, `repo_root`, `branch_name`) and owns three internal ports (`DiffReader`, `IssueResolver`, `SolutionsScanner`). Maximum future-proofing; orchestrator never changes when adapters are swapped.
+- **Why rejected:** Composition owning I/O ports is over-investing in future-proofing for a skill the orchestrator already drives. Testability of the public contract is weakest (must mock at internal port boundary via test-only entry). Observability is worst (cannot see what the diff range expanded to from the call site). **However, C's opaque-value philosophy for inputs was kept in the hybrid** — `IssueContext.raw`, generic `PreservedBlock`, generic `EvidenceItem` — exactly the parts that absorb schema drift without paying C's I/O ownership cost.
+
+## Scope Boundaries
+
+- **Not deploy.** Not merge. Not auto-approve.
+- **No automated evidence capture.** Accepts user-supplied screenshot URLs / Loom links only. The CE `ce-demo-reel` flow is explicitly out.
+- **No autonomous shipping.** Preview-then-confirm is mandatory before any `gh pr create` / `glab mr create` or any commit/push that creates new history.
+- **No code review.** That is `/ba:review`'s job, run separately.
+- **No automatic `ba:review` chaining.** User decides when to run review; the skill never triggers it implicitly.
+- **No squash-merge interpretation.** The skill writes commit and PR bodies; how the platform squashes is the platform's concern. `--diverge` is the only divergence path between commit and PR body.
+- **No `git add -A` / `git add .`** — explicit paths only, to avoid sweeping `.env`, build artifacts, and generated files.
+- **No `--no-verify` or hook-bypass flags** ever, unless user explicitly requests.
+- **The command does exactly three things:** commit, push, open PR/MR with a good message. Everything else is out.
+
+## Acceptance Criteria
+
+- A user on a feature branch can run `ba:propose`, see a previewed title and body, confirm, and have commits pushed and a PR/MR opened.
+- Branch routing handles all four CE cases: detached HEAD, default branch with uncommitted work, default branch with no work, feature branch.
+- Composition is host-agnostic; the same `compose_body` output feeds both `gh pr create --body-file` and `glab mr create --description-file`.
+- Cursor BugBot block (`<!-- CURSOR_SUMMARY --> … <!-- /CURSOR_SUMMARY -->`) and existing `## Demo` / `## Screenshots` blocks are preserved byte-identical when rewriting an existing PR/MR description.
+- Linear MCP integration: when an issue ID is supplied (or detected from branch name), motivation pulls from MCP; when absent, motivation derives from diff and recent commits — the command never errors on missing Linear.
+- `docs/solutions/` entries touched on the current branch since last merge are detected and offered for inclusion; user confirms before splicing.
+- `--body-file` discipline enforced: temp file + quoted-sentinel heredoc; never stdin, pipes, or `--body "$(cat ...)"`.
+- Commit body and PR/MR description share the same composed markdown — no separate commit-vs-PR rendering path.
+- The command never sweeps `.env` / build artifacts (no `git add -A` / `git add .`).
+- Title is effect-phrased — mechanism-only titles ("add a mutex to guard X") are rewritten to effect form ("prevent X during simultaneous Y") inside composition.
+- Description-only mode (`ba:propose --describe-only` or equivalent) prints the body without committing or pushing — for refreshing an existing PR description.
+
+## Open Questions
+
+*(All resolved before capture — see Resolved Questions.)*
+
+## Resolved Questions
+
+- **Namespace.** → `ba:propose` (under `ba:` prefix, alongside `ba:execute` / `ba:review` / `ba:compound`).
+- **Multi-platform.** → Single skill with host-detected dispatch (GitHub `gh` + GitLab `glab`); composition logic shared, branch routing / push / create diverge in a thin platform-adapter layer.
+- **Linear MCP integration.** → Optional source with diff-derived fallback when no issue is supplied or detected.
+- **`docs/solutions/` integration.** → Auto-detect entries touched on the current branch since last merge; offer to splice as "What I learned"; user confirms.
+- **Commit ↔ PR alignment.** → Aligned by default. (Originally proposed `--diverge` for squash-merge cases; dropped post-capture — see *2026-05-19 Addendum — `--diverge` dropped*.)
+- **Body composition design.** → Hybrid: A's pure-function composition + C's opaque value-object inputs (see `## Locked Design`).
+- **Command name.** → `ba:propose` (rejected: `ba:ship`, `ba:submit`, `ba:pr`, `ba:open`).
+- **CLAUDE.md command category.** → New **"Git workflow"** category, mirroring CE/Every's vocabulary. Plan must update CLAUDE.md `## Conventions` and README.
+- **Artifact terminology.** → "Command" (not "skill") throughout the brainstorm, matching dev-workflow's own vocabulary in `commands/ba/*.md`.
+
+## Convention Compliance
+
+Convention-checker run on 2026-05-19. Summary: 14 conventions checked, 8 aligned, 1 justified override (empty `## Open Questions` per template's expected pattern), 0 hard violations, 4 risks flagged.
+
+**Resolved during capture:**
+
+- **Terminology** (`ba:propose` referred to as "skill" in initial draft) — unified to "command" throughout to match the repo's own vocabulary (CLAUDE.md, README, `commands/ba/*.md` layout). `mr` and CE references retain "skill" because that's the source vocabulary of those artifacts.
+- **Command category** — `ba:propose` does not fit cleanly into any of CLAUDE.md's five existing buckets (Research / Planning / Execution / Quality / Knowledge). Added a Key Decision establishing a new **"Git workflow"** category, mirroring Every/CE's vocabulary. Plan is responsible for updating CLAUDE.md `## Conventions` and README accordingly.
+- **Orchestrator file references** — replaced placeholder `SKILL.md` references in `## Locked Design` with `commands/ba/propose.md`, matching the dev-workflow command-file convention.
+
+**Informational (no action):**
+
+- **Python type signatures in `## Locked Design`** — template-sanctioned (the brainstorm command's design-it-twice template at `commands/ba/brainstorm.md` explicitly expects entry points and signatures in `### Interface`). A stricter reading of CLAUDE.md's "planning commands must never write code" rule could flag the snippets, but they document a contract, not implementation.
+- **`Source:` line wording** — `"Hybrid: A's pure-function composition + C's opaque value-object inputs"` is the verbatim label of the option the user selected in the Phase 2 hybrid-phrasing AskUserQuestion. Lock-bound per the synthesis-lock rule.
+
+**Aligned (no action):**
+
+filename + frontmatter shape + required-section presence + design-it-twice template sections (Interface / Usage / What's hidden / Dependency strategy / Trade-offs) + `## Rejected Designs` shape + synthesis-lock paragraph + `ba:` command-prefix convention + scope-boundary explicitness.
+
+## Next Steps
+
+→ `/ba:plan` to create the implementation plan for `ba:propose`.
+
+---
+
+## 2026-05-19 Addendum — `--diverge` dropped
+
+**Captured during `/ba:plan` review (same day as brainstorm).** User pushed back: do we really need `--diverge`?
+
+**Resolution: drop it.**
+
+**Rationale (three reasons):**
+
+1. **The default (commit body = PR body) covers both squash and non-squash repos.** On squash-merge, the per-commit message is discarded at merge anyway — but Claude is generating it, not a human typing, so the "tighter commit body" optimization saves no human effort. The waste is conceptual, not real.
+
+2. **Preview-then-apply already covers ad-hoc divergence.** This brainstorm rejected Design B's public `overrides` taxonomy with exactly this reasoning (see `## Locked Design` rationale, line 23): *"preview-then-apply already covers ad-hoc overrides (just edit the preview)."* `--diverge` is the same class of feature — a flag that exists to express something the preview's Edit affordance already expresses. By Design B's logic, `--diverge` is a YAGNI trap.
+
+3. **The cost is disproportionate to the value.** `--diverge` would bring: a flag, a `.git/dev-workflow/propose-config` cache file, merge-flags hash invalidation, auto-prompt on squash-merge-only repos, a "settings changed" warning path, a dual-render (small-tier commit body + natural-tier PR body) inside composition, two paths through the preview. For a knob whose primary purpose is to make discarded content shorter.
+
+**Counter-case considered.** Multi-commit PRs where short per-commit checkpoint messages + a comprehensive PR description might be wanted. Resolution: the plan's multi-commit grouping (Step 5a) handles this naturally — each subset diff tier-classifies as "small" on its own, producing short per-commit bodies without a flag.
+
+**What this changes in the locked design.** Nothing in the `compose_body` contract. `--diverge` was always an orchestrator-side option applied as a final-step transform on the body; removing it just deletes that branch. The composition seam is unaffected.
+
+**What this changes in scope.** Removed from Key Decisions, Acceptance Criteria, and Resolved Questions. Plan (`docs/plans/2026-05-19-feat-add-ba-propose-command-plan.md`) updated in tandem.
+
+**Audit trail.** This addendum exists so a future reader can see that the brainstorm-time list of decisions was not silently rewritten — the original `--diverge` decision was made, then publicly retracted with a stated reason. The synthesis-lock rule (see `docs/brainstorms/2026-05-02-ousterhout-principles-roadmap-brainstorm.md` *Concrete rules*) is honored: locked decisions are not silently re-opened, but they may be retracted via an explicit, dated addendum that names what was dropped and why.

--- a/docs/plans/2026-05-19-feat-add-ba-propose-command-plan.html
+++ b/docs/plans/2026-05-19-feat-add-ba-propose-command-plan.html
@@ -1,0 +1,1406 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Plan — Add ba:propose Shipping Command</title>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css" media="(prefers-color-scheme: light)">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css" media="(prefers-color-scheme: dark)">
+<style>
+  :root {
+    --bg: #ffffff;
+    --fg: #1f2328;
+    --fg-muted: #57606a;
+    --border: #d0d7de;
+    --border-soft: #e6e8eb;
+    --accent: #0969da;
+    --accent-bg: #ddf4ff;
+    --code-bg: #f6f8fa;
+    --warn-bg: #fff8c5;
+    --warn-border: #d4a72c;
+    --sidebar-bg: #f9fafb;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #0d1117;
+      --fg: #e6edf3;
+      --fg-muted: #8b949e;
+      --border: #30363d;
+      --border-soft: #21262d;
+      --accent: #58a6ff;
+      --accent-bg: #1f3a5f;
+      --code-bg: #161b22;
+      --warn-bg: #3d2e00;
+      --warn-border: #8a6d00;
+      --sidebar-bg: #0d1117;
+    }
+  }
+  * { box-sizing: border-box; }
+  html { scroll-behavior: smooth; }
+  body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--fg);
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+    font-size: 16px;
+    line-height: 1.65;
+  }
+  .layout {
+    display: grid;
+    grid-template-columns: 300px minmax(0, 1fr);
+    max-width: 1400px;
+    margin: 0 auto;
+  }
+  @media (max-width: 960px) {
+    .layout { grid-template-columns: 1fr; }
+    aside { display: none; }
+  }
+  aside {
+    position: sticky;
+    top: 0;
+    align-self: start;
+    max-height: 100vh;
+    overflow-y: auto;
+    padding: 1.5rem 1rem 1.5rem 1.5rem;
+    background: var(--sidebar-bg);
+    border-right: 1px solid var(--border-soft);
+    font-size: 13.5px;
+  }
+  aside h3 {
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--fg-muted);
+    margin: 0 0 0.5rem;
+    border: none;
+    padding: 0;
+    font-weight: 600;
+  }
+  aside ol { list-style: none; padding: 0; margin: 0; }
+  aside li { margin: 0.1rem 0; }
+  aside li.depth-3 { padding-left: 1.1rem; font-size: 12.5px; }
+  aside li.depth-4 { padding-left: 2.2rem; font-size: 12px; color: var(--fg-muted); }
+  aside a {
+    display: block;
+    padding: 0.22rem 0.5rem;
+    color: var(--fg-muted);
+    text-decoration: none;
+    border-radius: 4px;
+    line-height: 1.3;
+  }
+  aside a:hover { color: var(--accent); background: var(--border-soft); }
+  aside a.active { color: var(--accent); background: var(--accent-bg); font-weight: 600; }
+  main {
+    padding: 2rem 3rem 6rem;
+    max-width: 920px;
+    min-width: 0;
+  }
+  @media (max-width: 960px) {
+    main { padding: 1.5rem 1.25rem 4rem; }
+  }
+  .meta-bar {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+    margin: 0 0 1.5rem;
+    padding: 0.6rem 0.8rem;
+    background: var(--code-bg);
+    border-radius: 6px;
+    font-size: 13px;
+  }
+  .meta-bar .pill {
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    padding: 0.12rem 0.7rem;
+    color: var(--fg-muted);
+  }
+  .meta-bar .pill strong { color: var(--fg); font-weight: 600; }
+  .meta-bar .pill a { color: var(--accent); text-decoration: none; }
+  h1, h2, h3, h4, h5 {
+    line-height: 1.3;
+    margin: 1.5em 0 0.5em;
+    font-weight: 600;
+  }
+  h1 {
+    font-size: 1.9rem;
+    border-bottom: 1px solid var(--border);
+    padding-bottom: 0.4em;
+    margin-top: 0.3em;
+  }
+  h2 {
+    font-size: 1.45rem;
+    border-bottom: 1px solid var(--border);
+    padding-bottom: 0.3em;
+    margin-top: 2.2em;
+  }
+  h3 {
+    font-size: 1.18rem;
+    border-left: 3px solid var(--accent);
+    padding-left: 0.65rem;
+    margin-top: 1.8em;
+  }
+  h4 { font-size: 1.02rem; color: var(--fg); margin-top: 1.4em; }
+  h5 {
+    font-size: 0.83rem;
+    color: var(--fg-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    margin-top: 1em;
+    margin-bottom: 0.3em;
+  }
+  .anchor {
+    color: var(--fg-muted);
+    text-decoration: none;
+    margin-left: 0.4rem;
+    opacity: 0;
+    font-weight: 400;
+    font-size: 0.85em;
+  }
+  h1:hover .anchor, h2:hover .anchor, h3:hover .anchor, h4:hover .anchor, h5:hover .anchor { opacity: 0.7; }
+  .anchor:hover { opacity: 1 !important; color: var(--accent); }
+  p, ul, ol { margin: 0.55em 0 0.95em; }
+  ul ul, ol ol, ul ol, ol ul { margin: 0.15em 0; }
+  li { margin: 0.18em 0; }
+  a { color: var(--accent); }
+  hr { border: 0; border-top: 1px solid var(--border); margin: 2.5em 0; }
+  code {
+    font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+    font-size: 0.87em;
+    background: var(--code-bg);
+    padding: 0.12em 0.4em;
+    border-radius: 4px;
+  }
+  pre {
+    background: var(--code-bg);
+    border-radius: 6px;
+    padding: 0.85rem 1rem;
+    overflow-x: auto;
+    line-height: 1.5;
+    border: 1px solid var(--border-soft);
+    margin: 0.9em 0;
+  }
+  pre code { background: transparent; padding: 0; font-size: 0.84em; }
+  blockquote {
+    margin: 1em 0;
+    padding: 0.6em 1em;
+    border-left: 4px solid var(--border);
+    background: var(--code-bg);
+    color: var(--fg-muted);
+  }
+  blockquote.phase-gate {
+    background: var(--warn-bg);
+    border-left: 4px solid var(--warn-border);
+    color: var(--fg);
+    font-weight: 500;
+  }
+  table {
+    border-collapse: collapse;
+    margin: 1em 0;
+    font-size: 0.94em;
+    display: block;
+    overflow-x: auto;
+    max-width: 100%;
+  }
+  thead { background: var(--code-bg); }
+  th, td {
+    border: 1px solid var(--border);
+    padding: 0.45rem 0.75rem;
+    text-align: left;
+    vertical-align: top;
+  }
+  th { font-weight: 600; }
+  tbody tr:nth-child(even) { background: var(--code-bg); }
+  ul.contains-task-list { list-style: none; padding-left: 0.3em; }
+  ul.contains-task-list li { padding-left: 0.2em; }
+  input[type="checkbox"] {
+    margin-right: 0.5em;
+    transform: translateY(2px);
+  }
+  /* Highlight the implementation-phase h3 blocks subtly */
+  h3:has(+ p), h3 {
+    scroll-margin-top: 0.5rem;
+  }
+  /* Make the print version sane */
+  @media print {
+    aside, .top-actions { display: none; }
+    .layout { display: block; }
+    main { padding: 0; max-width: none; }
+    a { color: inherit; text-decoration: none; }
+    pre, blockquote, table { break-inside: avoid; }
+  }
+</style>
+</head>
+<body>
+<div class="layout">
+<aside>
+  <h3>On this page</h3>
+  <ol id="toc"></ol>
+</aside>
+<main id="content"></main>
+</div>
+<script id="md" type="text/markdown">
+---
+title: "feat: Add ba:propose Shipping Command"
+type: feat
+status: active
+date: 2026-05-19
+origin: docs/brainstorms/2026-05-19-ba-propose-shipping-skill-brainstorm.md
+detail_level: comprehensive
+iteration_count: 1
+tags: [command, ba-propose, git-workflow, commit, pull-request, merge-request, body-composition]
+---
+
+# Add `ba:propose` Shipping Command — Implementation Plan
+
+## Overview
+
+Add a new `ba:propose` command to the `dev-workflow` plugin that commits, pushes, and opens a PR/MR with a composed title and body. The command introduces a new **Git workflow** command category alongside Research / Planning / Execution / Quality / Knowledge, and is the first command in the repo that issues `gh pr create` / `glab mr create` itself (existing `/ba:execute` delegates the act).
+
+The high-level design is locked at the brainstorm (see brainstorm: `docs/brainstorms/2026-05-19-ba-propose-shipping-skill-brainstorm.md` — *Locked Design*). The plan's job is to translate that design into the concrete command-markdown structure, document set, and version bump that ship `ba:propose` to v0.18.0.
+
+## Current State
+
+- **Command files** all live in `commands/ba/*.md` as self-contained markdown (8 files, 164–821 LoC each). `commands/ba/execute.md:419-437` already has a "Create MR/PR" completion menu that delegates to the user; `ba:propose` replaces that delegation with a concrete command.
+- **No existing command issues `gh pr create` / `glab mr create`.** Existing `gh`/`glab` usage is read-only — `commands/ba/review.md:76-86` invokes `gh pr diff`, `gh pr view`, `glab mr diff`, `glab mr view`.
+- **No `--body-file` heredoc precedent in the repo.** `commands/ba/plan.md:507` uses `gh issue create --title <t> --body-file <plan_path>` but that's the only existing `--body-file` usage, and it's for issues, not PRs. `ba:propose` establishes the multi-paragraph PR-body discipline for the first time.
+- **`docs/solutions/` directory does not yet exist** anywhere in the repo. `commands/ba/compound.md:55-61` already includes defensive handling ("If the directory doesn't exist or is empty, return 'No existing docs found'"); `ba:propose` follows the same defensive pattern.
+- **No Linear MCP integration precedent.** `commands/ba/plan.md:497-508` mentions Linear only as a tracker CLI (`linear issue create ...`), not as an MCP source. `ba:propose` establishes the optional-MCP-with-graceful-fallback pattern.
+- **Plugin version is `0.17.0`** at `.claude-plugin/plugin.json:3`. Marketplace version at `.claude-plugin/marketplace.json:11` is `0.1.0` (stale, not bumped per release historically — not in scope here).
+- **CLAUDE.md `## Commands` section** has five subsections — Research / Planning / Execution / Quality / Knowledge (`CLAUDE.md:5-28`). New "Git workflow" subsection lands between Knowledge and `## Agents` at line 29.
+- **README `## Commands` section** is flat — no subsection headings, each command has its own `### /ba:xxx` block (`README.md:36-197`). New `/ba:propose` block lands before `### Severity ladder…` at line 172.
+- **CE four-way branch decision tree, Lynch's 16-section menu, `--body-file` heredoc recipe, BugBot sentinel** all extracted verbatim in `docs/research/2026-05-17-shipping-skill-source-material-research.md`. (Squash-merge detection was also extracted but is no longer used — see brainstorm: *2026-05-19 Addendum — `--diverge` dropped*.)
+- **`docs/brainstorms/2026-05-02-ousterhout-principles-roadmap-brainstorm.md` `### Concrete rules`** is the standing synthesis-lock authority cited by the brainstorm (brainstorm line 157). Plan must respect the lock — refine, do not re-add rejected elements.
+
+## What We're NOT Doing
+
+- **Not writing Python code.** The locked design's `compose_body(inputs) -> ComposedBody` is a logical specification Claude executes from the command markdown — not an importable function (see brainstorm: `## Convention Compliance`, *Informational*). Type signatures stay as design contracts.
+- **Not creating `docs/solutions/`** as part of this rollout. Defer to first `/ba:compound` run.
+- **Not creating a sub-agent for body composition.** Composition is inlined as a clearly-delimited spec section in `commands/ba/propose.md`. Extracting to `agents/workflow/body-composer.md` later is a future plan if the spec grows past ~300 LoC of internal complexity.
+- **Not creating a `references/` directory pattern.** No existing command in the repo splits into helper markdown; `propose.md` is a single self-contained file like every other.
+- **Not implementing automated evidence capture** (CE's `ce-demo-reel`). Evidence is user-supplied URLs only.
+- **Not adding auto-`/ba:review` chaining.** User decides when to run review.
+- **Not handling deploy, merge, or auto-approve.** The command does three things: commit, push, open PR/MR.
+- **Not bumping `marketplace.json`.** Out of scope; not a per-command convention.
+- **Not adding a `--diverge` flag** for commit-vs-PR-body divergence (see brainstorm: *2026-05-19 Addendum — `--diverge` dropped*). The aligned-default plus the preview's Edit affordance handle ad-hoc divergence; the brainstorm's own rejection of Design B's `overrides` (YAGNI) applies here too.
+- **Not adding a roadmap entry** before release. Roadmap line gets `✅` after release if added at all.
+- **Not updating `commands/ba/execute.md`'s "Create MR/PR" completion menu** (currently `execute.md:419-437`) to point at `/ba:propose`. Out of scope for v0.18.0 to avoid blast-radius coupling between commands; tracked as [azevedo/dev-workflow#13](https://github.com/azevedo/dev-workflow/issues/13).
+
+## Behaviors to Test
+
+User-observable behaviors `ba:propose` must satisfy. Authored once here; serves scope, review, and test-coverage simultaneously. Each line is one structural grep or one manual scenario.
+
+- [ ] On a feature branch with new commits, running `/ba:propose` previews a title and body, then on confirmation pushes commits and opens a PR/MR.
+- [ ] Title is effect-phrased — when composition rewrites a mechanism-only title, the preview shows `Title: <effect-phrased>  (rewritten from: <original>)`.
+- [ ] When the remote host is `github.com` (or a GHES host inferred from remote URL), the command invokes `gh pr create --body-file <path>`.
+- [ ] When the remote host is `gitlab.com` (or a self-hosted GitLab), the command invokes `glab mr create --description-file <path>`.
+- [ ] When the remote host is neither GitHub nor GitLab, the command completes commit + push, prints the composed body, and tells the user the platform isn't supported — without ever calling `gh pr create` / `glab mr create`.
+- [ ] Cursor BugBot block (`<!-- CURSOR_SUMMARY --> … <!-- /CURSOR_SUMMARY -->`) is preserved byte-identical when rewriting an existing PR/MR description.
+- [ ] Existing `## Demo` and `## Screenshots` blocks are preserved byte-identical when rewriting an existing PR/MR description.
+- [ ] When a Linear issue ID is detected (supplied as arg or parsed from branch name) and the Linear MCP server responds, motivation is sourced from MCP.
+- [ ] When a Linear issue ID is detected but the Linear MCP server is unavailable, the preview shows a one-line warning ("Linear MCP unavailable — using diff-derived motivation") and the command continues without error.
+- [ ] When no Linear issue ID is present, the command never errors on missing Linear; motivation is derived from the diff and recent commits.
+- [ ] `docs/solutions/` entries touched on the current branch since the last merge to `origin/HEAD` are detected and presented one-by-one for inclusion confirmation; the user can accept any subset.
+- [ ] No `gh pr create` / `glab mr create` invocation uses `--body "$(cat ...)"`, stdin, pipes, or `--body-file -`. Every invocation uses `--body-file <temp_path>` (or `--description-file <temp_path>`) where `<temp_path>` was written by a quoted-sentinel heredoc.
+- [ ] Commit message and PR/MR body share the same composed markdown — no separate per-commit-vs-PR rendering path.
+- [ ] Staging uses explicit paths only — no `git add -A`, no `git add .` anywhere in the command's bash blocks.
+- [ ] No `--no-verify` flag is passed to `git commit` or `git push` anywhere.
+- [ ] On pre-commit / commit-msg hook failure, the command surfaces hook output, leaves the working tree intact, and exits with a clear "fix the hook and re-run" message — never with `--no-verify`.
+- [ ] `--describe-only` prints the composed body without committing or pushing; on a branch with no open PR/MR it composes and prints, returning zero.
+- [ ] When the command is run on a feature branch that has an open PR/MR, it switches to edit semantics (`gh pr edit --body-file` / `glab mr update --description-file`) instead of failing with "PR already exists."
+- [ ] Branch routing handles all four CE cases — detached HEAD, default branch with uncommitted work, default branch with no work, feature branch.
+- [ ] The command never issues a force-push silently; non-fast-forward push prompts the user to use `--force-with-lease` or abort.
+- [ ] Empty-diff (feature branch fully contained in base) raises a `CompositionInputError` with the message "branch is fully contained in base; rebase or close."
+- [ ] Preview-abort returns the user to a menu: edit body, regenerate with a one-line hint, or exit. The flow never silently exits or silently recomposes.
+- [ ] CLAUDE.md gains a new `### Git Workflow Commands` subsection and a new convention bullet; README gains a new `### /ba:propose` block.
+- [ ] `.claude-plugin/plugin.json` version is bumped to `0.18.0`, `description` includes "propose", and `keywords` array includes `"propose"`.
+
+## Proposed Solution
+
+Ship `ba:propose` as a single comprehensive command file `commands/ba/propose.md` containing:
+
+1. **Frontmatter** — `name: ba:propose`, instruction-to-Claude description, argument-hint covering `[--describe-only] [--issue <ID>]`.
+2. **Argument capture** — `<propose_args> #$ARGUMENTS </propose_args>` block following the established pattern (`commands/ba/execute.md:13`).
+3. **Orchestrator step sequence** — Step 0 (pre-flight: host + mode detection) → Step 1 (branch routing) → Step 2 (gather inputs) → Step 3 (compose body — the seam) → Step 4 (preview) → Step 5 (apply: commit, push, create-or-edit PR/MR).
+4. **Composition spec** — a clearly-delimited section that documents the `compose_body` contract: inputs, tier classifier, section selector, splicer, title rewriter, invariants. Claude executes this spec at runtime.
+5. **Failure modes** — explicit recovery flows for hook failure, push rejection, post-push PR-create failure, unknown host, MCP unavailability, preserved-block staleness, empty diff, body-too-large warning.
+
+Outside the command file, three documents update: `CLAUDE.md` (new category + convention bullet), `README.md` (new `### /ba:propose` block), `.claude-plugin/plugin.json` (version, description, keywords).
+
+## Technical Approach
+
+### Architecture
+
+```
+                  ┌─────────────────────────────────────────────────┐
+                  │  commands/ba/propose.md  (single-file command)  │
+                  └─────────────────────────────────────────────────┘
+                                          │
+        ┌─────────────────────────────────┼─────────────────────────────────┐
+        │                                 │                                 │
+        ▼                                 ▼                                 ▼
+   Orchestrator              Composition Spec (seam)          Platform Adapter
+   (gather inputs            (pure-function contract,         (host detection,
+   from git, MCP,            tier+section+splice+title,       gh/glab dispatch,
+   solutions, evidence)      no I/O reach-out)                heredoc-to-tempfile,
+                                                              create-or-edit)
+```
+
+- **Orchestrator** owns I/O — git, `gh repo view`, Linear MCP, `docs/solutions/` scan, preserved-block extraction, user-supplied evidence prompts.
+- **Composition spec** is pure; consumes only the value objects from `CompositionInputs`. Stateless, deterministic, idempotent. All editorial judgment lives here.
+- **Platform adapter** is a thin layer that handles host detection (parse `git remote get-url origin`), maps to `gh` or `glab` commands, applies the `--body-file` heredoc recipe, and detects "PR already exists" → switches to edit.
+
+This mirrors the brainstorm's locked design (see brainstorm: `## Locked Design`, *Dependency strategy*): pure composition + I/O-owning orchestrator + thin host adapter, no Linear/MCP/git knowledge inside composition.
+
+### Alternative Approaches Considered
+
+- **Composition as a sub-agent (`agents/workflow/body-composer.md`).** Rejected. The agent precedent is small (74–129 LoC) and single-purpose, but composition needs the same context the orchestrator has just gathered — making it a separate agent means re-passing all those inputs through a Task call, which is a serialization tax with no architectural payoff. The brainstorm's pure-function seam already gives the testability and swap-ability we need without crossing an agent boundary. A future plan can extract if internal complexity warrants.
+- **Two commands — `ba:commit` and `ba:open`.** Rejected. The brainstorm names `ba:propose` and resolves the namespace question (see brainstorm: `## Resolved Questions`, "Namespace"). Two commands also fragment the body — the same composed body should feed both commit and PR/MR by default.
+- **A `references/` directory pattern** — separating composition spec from orchestrator narrative. Rejected. No repo precedent; CLAUDE.md convention update would be required; single-file precedent is robust and reviewable.
+- **Embedding the spec as a sub-document at `commands/ba/propose/composition.md`.** Same rejection rationale — net-new convention, no payoff over a section heading inside the main file.
+- **Auto-creating `docs/solutions/`** as part of this plan. Rejected. The brainstorm doesn't require it, and `commands/ba/compound.md:56` already documents the "directory absent → return 'no docs found'" defensive pattern; `ba:propose` follows the same pattern. Pre-creating the directory introduces noise without benefit.
+
+## Implementation Phases
+
+### Phase 1 — Command scaffold, frontmatter, mode dispatch, branch routing
+
+Lay down `commands/ba/propose.md` with the frontmatter, argument capture, mode-dispatch logic, host detection, and branch-routing decision tree. No body composition yet — Phase 1 ends with a command that can identify what mode it's in, detect the host, route correctly across the four CE branch states, and refuse cleanly on unsupported hosts or detached HEAD.
+
+#### Changes Required
+
+**File**: `commands/ba/propose.md` (new file)
+
+````markdown
+---
+name: ba:propose
+description: Commit, push, and open a PR/MR with a composed title and body — preview-then-confirm, host-detected dispatch for GitHub and GitLab.
+argument-hint: "[--describe-only] [--issue <ID>] [optional: free-text hint]"
+---
+
+# Propose Changes for Review
+
+Compose a commit and PR/MR body that helps the code reviewer first, teammates and future-bug-investigators next.
+
+## Arguments
+
+<propose_args> #$ARGUMENTS </propose_args>
+
+### Parse Arguments
+
+Strip recognized flags from the argument string; what remains is a free-text hint that the user wants reflected in motivation.
+
+Recognized flags:
+
+- `--describe-only` — Compose and print the body; do not commit, push, or create/edit a PR/MR. Useful as a dry run.
+- `--issue <ID>` — Explicitly bind a Linear issue ID. Overrides branch-name detection.
+
+Note: there is no explicit `--describe-update` flag. When the command is run on a feature branch with an existing open PR/MR, Steps 2d and 5d auto-detect the open PR and switch to edit semantics (`gh pr edit` / `glab mr update`) without requiring a mode flag. If the user is on a branch with no new commits to push *and* an open PR exists, Step 0b asks whether to update the PR description only — the answer drives the same code path. One flag, one auto-detection — no parallel surface.
+
+## Step 0: Pre-flight
+
+### 0a. Detect remote host
+
+```bash
+REMOTE_URL=$(git remote get-url origin 2>/dev/null || echo "")
+```
+
+Parse `REMOTE_URL` to classify:
+
+- Matches `github.com` → `HOST=github`, `CLI=gh`.
+- Matches `gitlab.com` → `HOST=gitlab`, `CLI=glab`.
+- Else parse the host from the remote URL and probe (in order):
+  - If `$GH_HOST` is already set in the environment AND matches the parsed host → `HOST=ghes`, `CLI=gh`.
+  - Else attempt `gh api /meta --hostname <parsed_host> 2>/dev/null`. Success (returns a JSON object with `github_services_sha`) → `HOST=ghes`, `CLI=gh`, `export GH_HOST=<parsed_host>`.
+  - Else attempt `glab config get -g host` and check whether the parsed host is registered. Match → `HOST=gitlab-self`, `CLI=glab`.
+  - All probes failed → `HOST=unknown`.
+- No remote at all → `HOST=unknown`.
+
+If `HOST=unknown`, announce: "Remote `<URL>` is not GitHub or GitLab. `ba:propose` will still commit and push, but cannot open the PR/MR — paste the composed body into your platform's web UI when prompted."
+
+### 0b. Detect mode
+
+```bash
+MODE=full
+[[ "$ARGS" == *--describe-only* ]] && MODE=describe-only
+```
+
+If `MODE=full` AND `git rev-list @{upstream}..HEAD 2>/dev/null` returns empty (nothing to push) AND an open PR/MR exists for the branch, ask:
+
+> "Nothing to push. Update the PR description only?"
+>
+> 1. **Yes** — skip commit/push, proceed to Step 5d which auto-detects the open PR and edits it
+> 2. **No** — exit (nothing to do)
+
+A `Yes` answer sets an internal `skip_push = True` orchestrator flag. Step 5 reads this flag and skips Steps 5a-5c; Step 5d runs as normal and finds the existing PR via `gh pr view` / `glab mr view`, dispatching to `gh pr edit` / `glab mr update`.
+
+## Step 1: Branch routing
+
+```bash
+git status --porcelain=v2 --branch
+git rev-parse --abbrev-ref HEAD
+```
+
+Detect branch state and route per CE's four-way decision tree (see `docs/research/2026-05-17-shipping-skill-source-material-research.md` *Branch routing*):
+
+| State | Behavior |
+|---|---|
+| Detached HEAD | Ask: "Detached HEAD — create a feature branch from these commits? Suggested name: `<derived-from-diff>`." If yes, `git checkout -b <name>` and continue. If no, refuse. |
+| Default branch with uncommitted work | Ask: "You're on `<default>` with uncommitted work. Create a feature branch? Suggested name: `<derived-from-diff>`." If yes, `git checkout -b <name>` and continue. If no, refuse. |
+| Default branch with no work | Refuse: "On `<default>` with nothing to propose. Switch to a feature branch first." |
+| Feature branch | Continue. |
+
+**Default-branch detection** (used above):
+
+```bash
+DEFAULT_BRANCH=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's@^origin/@@')
+[[ -z "$DEFAULT_BRANCH" ]] && DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name 2>/dev/null)
+[[ -z "$DEFAULT_BRANCH" ]] && DEFAULT_BRANCH=$(git remote show origin 2>/dev/null | awk '/HEAD branch/ {print $NF}')
+```
+
+If still empty, ask the user.
+
+## Step 2: … (continued in Phase 2)
+````
+
+#### Success Criteria
+
+##### Automated:
+- [ ] `ls commands/ba/propose.md` — file exists
+- [ ] `head -5 commands/ba/propose.md` — frontmatter starts with `name: ba:propose`
+- [ ] `grep -c '#\$ARGUMENTS' commands/ba/propose.md` — argument capture present (>= 1)
+- [ ] `grep -c 'AskUserQuestion' commands/ba/propose.md` — interactive prompts present (>= 5 by end of plan)
+- [ ] `grep -c '^## Step ' commands/ba/propose.md` — step structure present (>= 1 after Phase 1; >= 6 after Phase 5)
+- [ ] `grep -E 'git add -A|git add \.' commands/ba/propose.md` — returns empty (no bulk staging)
+- [ ] `grep '\--no-verify' commands/ba/propose.md` — returns empty (no hook bypass)
+- [ ] `grep 'github.com\|gitlab.com' commands/ba/propose.md` — both hosts referenced
+- [ ] `grep 'Detached HEAD\|default branch' commands/ba/propose.md` — all four branch states mentioned
+
+##### Manual:
+- [ ] Frontmatter matches the universal command shape (`name`, `description`, `argument-hint`).
+- [ ] Prose voice is instruction-to-Claude (imperative, "Run …", "Ask …") — matching `commands/ba/execute.md` and `commands/ba/review.md`.
+- [ ] Host-detection branch enumerates GHES and self-hosted GitLab explicitly, with a graceful unknown-host path.
+
+> **Phase gate:** Automated verification must pass. Pause for manual verification before proceeding to Phase 2.
+
+---
+
+### Phase 2 — Input gathering (diff, branch, Linear, solutions, preserved blocks, evidence)
+
+Add Step 2 to the command file: the orchestrator's input-gathering steps that materialize `CompositionInputs` for the composition seam. Linear MCP optional with explicit failure-vs-absence distinction; `docs/solutions/` scan with per-entry confirmation; preserved-block extraction from existing PR body (re-extracted at apply time in Step 5d to close the BugBot-edit race window without explicit hash compare); evidence prompt.
+
+#### Changes Required
+
+**File**: `commands/ba/propose.md` (append Step 2)
+
+````markdown
+## Step 2: Gather inputs
+
+Each sub-step materializes one field of `CompositionInputs`. None of this happens inside composition.
+
+### 2a. Diff and branch metadata
+
+```bash
+git fetch --no-tags origin "$DEFAULT_BRANCH"
+DIFF_BASE=$(git merge-base HEAD "origin/$DEFAULT_BRANCH")
+git diff --stat "$DIFF_BASE..HEAD"
+git diff --numstat "$DIFF_BASE..HEAD"
+git log --pretty=oneline "$DIFF_BASE..HEAD"
+git rev-parse --abbrev-ref HEAD
+```
+
+Capture into the orchestrator's local state:
+
+- `diff.range = "$DIFF_BASE..HEAD"`
+- `diff.file_stats = <output of --numstat>`
+- `diff.commit_log = <output of --pretty=oneline>`
+- `branch.name = <current branch>`
+- `branch.base_ref = "origin/$DEFAULT_BRANCH"`
+- `branch.last_merge_sha = "$DIFF_BASE"`
+
+If `git diff --stat "$DIFF_BASE..HEAD"` is empty AND there are commits in the log, raise the empty-diff error:
+
+> **CompositionInputError: branch is fully contained in base.**
+> Your commits exist but the diff vs `<DEFAULT_BRANCH>` is empty. Likely causes: someone landed equivalent changes in `<DEFAULT_BRANCH>` and your branch is now redundant, or the base was force-pushed past your branch tip. Rebase, or close the branch.
+
+If `git diff --stat` is non-empty but unreadable (returns non-zero with no diff), raise:
+
+> **CompositionInputError: diff unreadable.**
+> `git diff $DIFF_BASE..HEAD` returned non-zero. Check the repository state.
+
+### 2b. Linear issue context (optional)
+
+Determine the issue ID:
+
+1. If `--issue <ID>` was passed, use it.
+2. Else, regex-extract from branch name: `[A-Z]{2,5}-[0-9]+` (e.g., `bru/TO-1234-fix-x` → `TO-1234`).
+3. Else, no issue ID — skip MCP entirely, `issue_context = None`.
+
+If an ID is present, attempt the MCP call:
+
+```
+mcp__claude_ai_Linear__get_issue(id: <ID>)
+```
+
+- **Success** → `issue_context = IssueContext(raw=<mcp response>)`. Composition reads whatever fields it needs.
+- **Failure** (MCP not installed, server down, auth expired, ID not found) → `issue_context = None`, AND record `mcp_unavailable = True` so the preview can surface a warning: "Linear MCP unavailable — using diff-derived motivation."
+
+The orchestrator never raises on MCP failure. Linear is optional.
+
+`mcp_unavailable` is **orchestrator-side state only** — it lives in the run-local variables alongside `DIFF_BASE`, `DEFAULT_BRANCH`, etc. It never flows into `CompositionInputs`; composition makes no decision based on it. The flag's sole consumer is the preview warning prefix in Step 4.
+
+### 2c. `docs/solutions/` auto-detection
+
+If `docs/solutions/` exists at the repo root:
+
+```bash
+git log "$DIFF_BASE..HEAD" --name-only --pretty=format: -- docs/solutions/ | sort -u
+```
+
+For each entry returned:
+
+- Read the file's frontmatter and the first paragraph of `## Solution` (or first paragraph of body if no `## Solution`).
+- Prepare a one-line summary: `<frontmatter.problem or H1>` — link target relative to repo root.
+
+If at least one entry was returned, ask the user **per-entry** via AskUserQuestion:
+
+> "Found `docs/solutions/<path>`: '<summary>'. Include as 'What I learned'?"
+>
+> 1. **Include** — add to the splice set
+> 2. **Skip** — do not add
+> 3. **Include all remaining** — accept the rest without further prompts
+> 4. **Skip all remaining** — reject the rest
+
+`solutions = (<accepted entries>...)`. Empty tuple is normal.
+
+If `docs/solutions/` does not exist or returns no entries, set `solutions = ()` silently.
+
+### 2d. Preserved blocks from existing PR/MR description
+
+If an open PR/MR exists for the current branch:
+
+```bash
+# GitHub
+gh pr view --json url,state,body,isDraft
+
+# GitLab
+glab mr view -F json
+```
+
+If `state == OPEN`:
+
+- Extract `<!-- CURSOR_SUMMARY --> … <!-- /CURSOR_SUMMARY -->` block(s) — preserved verbatim.
+- Extract `## Demo` section (heading + content until next H2 or EOF).
+- Extract `## Screenshots` section (same shape).
+
+`preserved_blocks = ((kind="bugbot", raw_markdown=<text>), (kind="demo", raw_markdown=<text>), (kind="screenshots", raw_markdown=<text>))` — only kinds present.
+
+Step 5d re-fetches the body immediately before write and re-extracts these blocks at apply time — see Step 5d for the rationale. The Step 2d extract is what the preview displays; Step 5d's extract is what actually ships.
+
+If `MODE=full` and no open PR/MR, set `preserved_blocks = ()`.
+
+### 2e. Evidence (user-supplied URLs only)
+
+If the diff suggests user-observable behavior — UI files changed, e.g. files matching `*.tsx`, `*.jsx`, `*.vue`, `*.svelte`, `*.css`, `templates/`, `views/`, etc. — ask:
+
+> "This change appears user-visible. Include evidence?"
+>
+> 1. **Use existing evidence** — paste URL(s) or markdown embed → splice as `## Demo`
+> 2. **Skip** — no evidence section
+
+If "Use existing evidence", prompt for the markdown to splice. Accept whatever the user pastes verbatim (URL validation is out of scope — preview catches obvious issues).
+
+`evidence = ((kind="markdown", raw=<text>),)` or `()`.
+
+If no user-observable files changed, skip this prompt — `evidence = ()`.
+````
+
+#### Success Criteria
+
+##### Automated:
+- [ ] `grep 'mcp__claude_ai_Linear__get_issue' commands/ba/propose.md` — MCP tool referenced
+- [ ] `grep 'CompositionInputError' commands/ba/propose.md` — error types defined
+- [ ] `grep 'CURSOR_SUMMARY' commands/ba/propose.md` — BugBot sentinel mentioned
+- [ ] `grep '## Demo\|## Screenshots' commands/ba/propose.md` — preserved-block kinds enumerated
+- [ ] `grep 'docs/solutions/' commands/ba/propose.md` — solutions integration present
+- [ ] `grep 'origin/HEAD\|DEFAULT_BRANCH' commands/ba/propose.md` — default-branch detection present
+- [ ] `grep -c 'AskUserQuestion' commands/ba/propose.md` — interactive prompts increased (>= 8)
+
+##### Manual:
+- [ ] Linear-failure vs Linear-absence distinction is explicit; `mcp_unavailable` flag is set on failure.
+- [ ] `docs/solutions/` scan is per-entry confirmable; "include all"/"skip all" shortcuts present.
+- [ ] Preserved-block extraction is re-run at apply time in Step 5d (not compared by hash) so the published body always reflects the freshest remote read.
+- [ ] Evidence prompt only triggers on heuristic UI-file detection; otherwise silent.
+- [ ] Empty-diff distinguishes "branch fully contained in base" from "diff unreadable" with separate messages.
+
+> **Phase gate:** Automated verification must pass. Pause for manual verification before proceeding to Phase 3.
+
+---
+
+### Phase 3 — Composition spec (the seam)
+
+Document the `compose_body` contract inline in `commands/ba/propose.md` as Step 3. This is the section Claude reads to compute `title` and `body` from `CompositionInputs`. The brainstorm's locked design (interface, invariants, tier→section mapping, swappable internals) lifts in verbatim where it's contract-shaped.
+
+#### Changes Required
+
+**File**: `commands/ba/propose.md` (append Step 3)
+
+````markdown
+## Step 3: Compose body (the seam)
+
+This is the composition spec — Claude executes it to produce `title` and `body` from the inputs gathered in Step 2. It is pure: it reads from `CompositionInputs` only, performs no I/O, makes no MCP calls, runs no git commands. If you find yourself needing a fact that isn't in `CompositionInputs`, that's a gather-side bug — go back to Step 2.
+
+### Contract
+
+**Inputs** (already materialized in Step 2):
+
+```
+CompositionInputs:
+  diff               # range, file stats, commit log
+  branch             # name, base ref, last merge SHA
+  issue_context      # opaque Mapping or None
+  solutions          # tuple of accepted entries, possibly empty
+  preserved_blocks   # tuple of (kind, raw_markdown), possibly empty
+  evidence           # tuple of (kind, raw), possibly empty
+```
+
+**Outputs**:
+
+```
+ComposedBody:
+  title              # effect-phrased, ≤72 chars, no trailing period
+  body               # final markdown — feeds both commit and PR/MR
+```
+
+(See brainstorm: `## Locked Design`, *Interface*.)
+
+### Invariants (every composition pass must satisfy these)
+
+- `body` never restates the diff verbatim. The diff is visible on the platform; the body explains what the diff cannot show.
+- `title` is effect-phrased. If the initial draft is mechanism-only (e.g., "add a mutex to guard X"), rewrite to effect form ("prevent X during simultaneous Y") and stash the original for the preview's "rewritten from" disclosure.
+- Preserved blocks appear exactly once, byte-identical to input. Splice positions chosen internally.
+- Section order follows Lynch's priority (descriptive title → impact → motivation → breaking changes → external refs → dependency justifications → cross-refs → bug summaries → testing instr → testing limits → what I learned → alternatives → searchable artifacts → screenshots → rants → tempted-to-explain).
+- Empty inputs (no Linear, no solutions, no preserved blocks, tiny diff) still produce a valid minimal body.
+- Stateless; deterministic given identical inputs.
+
+Errors collapse to `CompositionInputError` — raised only by Step 2 when the diff is unreadable or empty. Composition itself does not raise.
+
+### Internal pipeline (seam-hidden, swappable)
+
+The implementation below is the first cut. Future authors can swap to pure-Lynch, pure-CE, or a continuous-score scheme without changing the call site. None of these names ("tier", "section selector", "splicer") appear in the orchestrator.
+
+#### 3.1 Classify size tier
+
+Read `diff.file_stats` and `diff.commit_log`. Compute totals:
+
+- `lines_changed = sum(additions + deletions across all files)`
+- `files_changed = count of files`
+- `is_perf = (lines_changed >= 30 AND any commit message in branch matches /perf|performance/) OR (diff includes a benchmark or measurement file — paths matching *bench*, *benchmark*, *measure*, *perf-test*, or files with `.bench.` infix)`
+- `is_typo = files_changed == 1 AND lines_changed <= 4 AND the change is pure string/comment/whitespace — no operators, no conditionals, no call expressions, no type annotations`
+
+Tier table (first match wins):
+
+| Tier | Heuristic |
+|---|---|
+| typo | `is_typo` |
+| perf | `is_perf` |
+| small | `lines_changed <= 30 AND files_changed <= 3` |
+| medium | `lines_changed <= 200 AND files_changed <= 10` |
+| large | otherwise |
+
+#### 3.2 Select default Lynch sections per tier
+
+Reference numbers are Lynch's menu (see `docs/research/2026-05-17-shipping-skill-source-material-research.md` *Source 4*).
+
+| Tier | Default sections |
+|---|---|
+| typo | #1 |
+| small | #1, #2, conditionally #3 if non-obvious motivation |
+| medium | #1, #2, #3, #7 (cross-refs), conditionally #9, #14, #11 |
+| large | #1, #2, #3, #4 (if breaking), #6 (if dep changes), #7, #8, #9, #10, #11, #12, #14 |
+| perf | #1, #2, #3, #14 (before/after table) |
+
+#### 3.3 Filter sections by content availability
+
+Drop any default section whose source is missing:
+
+- No `issue_context` → drop "Motivation from issue" sub-flavor of #3; derive motivation from `diff.commit_log` instead.
+- No `solutions` entries → drop #11.
+- No detected breaking change in diff (no API removal, no schema change) → drop #4.
+- No lockfile / dependency-manifest changes → drop #6.
+- No `evidence` AND no `preserved_blocks` of kind `demo`/`screenshots` → drop #14.
+
+#### 3.4 Generate section bodies
+
+For each surviving section, generate copy from the relevant inputs:
+
+- **#1 Title** — see 3.5 below.
+- **#2 Impact** — one sentence: what was impossible/broken before, what's possible/fixed now.
+- **#3 Motivation** — pull from `issue_context.raw` if present (read whatever fields exist; common shapes: `title`, `description`, `priority`); else derive from `diff.commit_log` and changed file paths.
+- **#4 Breaking changes** — name the breaking surface (removed API, schema migration, etc.) under a `**BREAKING:**` line. Never use `!` in the title or `BREAKING CHANGE:` trailer without explicit user confirmation.
+- **#6 Dependency justifications** — list lockfile-detected adds; one-line rationale per addition.
+- **#7 Cross-refs** — `Fixes <issue_context.identifier>` if applicable; never prefix list items with `#` (auto-links `#1` as issue ref — use `org/repo#N` or full URL).
+- **#8 Bug summaries** — paragraph form, never just `Fixes #N`. Pull from `issue_context.raw.description` if available.
+- **#9 Testing instructions** — only when automated tests don't exist for the change.
+- **#10 Testing limitations** — disclose what wasn't tested.
+- **#11 What I learned** — for each `solutions` entry, render as a bullet linking to the file with the entry's summary.
+- **#12 Alternatives considered** — only when the diff isn't self-explanatory.
+- **#14 Screenshots / Demo** — splice `evidence` markdown verbatim; if `preserved_blocks` includes `demo`/`screenshots`, prefer those byte-identical.
+
+#### 3.5 Title rewriting
+
+Draft a title from `diff.commit_log[0]` or the user's free-text hint if provided.
+
+Check for mechanism-only phrasing — leading verbs like `add`, `move`, `extract`, `refactor`, `update`, `change`, `bump`, `wrap` followed by a noun phrase that names a code construct (`mutex`, `class`, `function`, `field`, etc.) without naming the user-observable effect.
+
+If mechanism-only, rewrite to effect form. Stash the original as `rewritten_from` for the preview's disclosure line. Worked example from Lynch — keep in mind when judging:
+
+| Bad (mechanism) | Good (effect) |
+|---|---|
+| Add a mutex to guard the database handle | Prevent database corruption during simultaneous sign-ups |
+
+Cap at 72 chars. Strip trailing period. Imperative mood. Lowercase after the conventional-commits prefix.
+
+**`fix:` vs `feat:` rule** (from CE / `pr-description-writing.md`): when both fit, default to `fix:` — adding code to remedy missing behavior is `fix:`. Reserve `feat:` for capabilities the user could not previously accomplish.
+
+#### 3.6 Splice preserved blocks
+
+After sections are rendered, splice preserved blocks at their canonical positions:
+
+- `## Demo` → after #2 / #3, before #11.
+- `## Screenshots` → after `## Demo`, or in `## Demo`'s slot if no `## Demo`.
+- `<!-- CURSOR_SUMMARY --> … <!-- /CURSOR_SUMMARY -->` → at the very end of the body, after all generated sections and after any rants/tempted-to-explain content.
+
+Byte-identical: the raw markdown carried in `preserved_blocks` is inserted as-is. Do not re-format, re-indent, or alter whitespace.
+
+#### 3.7 Final assembly
+
+Commit message and PR/MR body share the same rendered string: `title + "\n\n" + body`. No per-commit-vs-PR divergence is computed here. If the user wants a tighter commit body than the PR body on a given run, they edit the preview (Step 4) — Per the brainstorm's *2026-05-19 Addendum — `--diverge` dropped*, the YAGNI rejection of Design B's `overrides` applies here too.
+
+#### 3.8 Soft size cap warning
+
+After full composition, count body lines. If `body` exceeds 150 lines (Lynch's soft cap for large tier), record a `size_warning = True` flag for the preview. Do not auto-trim — the user decides.
+
+### Trade-offs documented at lock time
+
+The seam intentionally exposes no tier flag, section list, template selector, or ordering hint to the orchestrator. Section-choice debugging requires reading this spec. If observability becomes a real pain point, add a `ComposedBody.trace` field later. (See brainstorm: `## Locked Design`, *Trade-offs*.)
+````
+
+#### Success Criteria
+
+##### Automated:
+- [ ] `grep '## Step 3' commands/ba/propose.md` — composition section exists
+- [ ] `grep -c 'tier' commands/ba/propose.md` — tier logic documented (>= 5 occurrences)
+- [ ] `grep 'CompositionInputs\|ComposedBody' commands/ba/propose.md` — contract types named
+- [ ] `grep 'Lynch' commands/ba/propose.md` — Lynch attribution present
+- [ ] `grep 'effect-phrased\|effect, not mechanism\|mechanism' commands/ba/propose.md` — title rewriting rule documented
+- [ ] `grep 'mutex.*sign-ups\|database corruption' commands/ba/propose.md` — Lynch worked example carried over
+- [ ] `grep '72 char\|72-char\|≤72\|<=72' commands/ba/propose.md` — title cap documented
+- [ ] `grep '150 line\|150-line\|>= 150\|>150' commands/ba/propose.md` — soft cap documented
+
+##### Manual:
+- [ ] Composition spec is clearly a contract Claude executes, not Python to import — phrased as instruction.
+- [ ] Section-vocabulary choice is visibly seam-hidden — the orchestrator never names a tier or section.
+- [ ] Linear MCP shape is read defensively (`issue_context.raw.<field> if available`), absorbing schema drift.
+- [ ] Filter step lists exact "drop section if source missing" rules from the brainstorm.
+
+> **Phase gate:** Automated verification must pass. Pause for manual verification before proceeding to Phase 4.
+
+---
+
+### Phase 4 — Preview, apply, failure-mode handling
+
+Add Steps 4 and 5: the preview/confirm gate, then the apply mechanics — `git commit` with `-F`, file-level staging, `git push` with non-fast-forward handling, `gh pr create` / `glab mr create` with `--body-file` heredoc discipline, edit-vs-create branching when an open PR/MR exists, hook-failure recovery, post-push PR-create failure messaging. Plus the explicit Failure Modes appendix.
+
+#### Changes Required
+
+**File**: `commands/ba/propose.md` (append Steps 4, 5, and Failure Modes)
+
+````markdown
+## Step 4: Preview and confirm
+
+Print the preview block:
+
+```
+─────────────────────────────────────────
+Mode: <full | describe-only>  (Host: <github|gitlab|...>)
+Title: <title>
+       (rewritten from: <rewritten_from>)             [if applicable]
+Body lines: <N>                                       size warning if N > 150
+Lead: <first two sentences of body>
+─────────────────────────────────────────
+[full body printed below]
+─────────────────────────────────────────
+```
+
+Tier observability is deliberately omitted from the preview — exposing the seam-internal vocabulary would break the "tier never named at call site" invariant from Step 3. If tier debugging becomes a real pain point, add an optional `ComposedBody.trace` field per the brainstorm's *Locked Design > Trade-offs*.
+
+Pre-prefix the block with warnings if any:
+
+- `⚠ Linear MCP unavailable — using diff-derived motivation` (from Step 2b)
+- `⚠ Composed body is <N> lines; Lynch's soft cap is ~150` (from Step 3.8)
+
+Then ask via AskUserQuestion:
+
+> "Apply?"
+>
+> 1. **Apply** — proceed to Step 5
+> 2. **Edit body** — open the body in `$EDITOR` (fallback `nano`), re-preview after save
+> 3. **Regenerate with hint** — prompt for a one-line hint, re-run Step 3 with the hint, re-preview
+> 4. **Exit** — abort without changes
+
+Loop until the user picks Apply or Exit.
+
+## Step 5: Apply
+
+Compose the per-mode action plan:
+
+| Mode / state | Actions |
+|---|---|
+| `full` (default) | 5a (stage) → 5b (commit) → 5c (push) → 5d (create or edit PR/MR — auto-detected) |
+| `full` + `skip_push=True` (nothing to push + open PR; user said "update description only") | 5d only (edits existing PR/MR) |
+| `describe-only` | print body to stdout; exit |
+
+### 5a. Stage explicit paths
+
+Identify the changed files from Step 2a's `--numstat` output. Stage all of them in a single commit using explicit paths only — no `git add -A`, no `git add .`:
+
+```bash
+git add path/to/file1 path/to/file2 path/to/file3
+```
+
+The command always produces one commit per run. Users who want multiple commits run `/ba:propose` twice on separately-staged subsets — the user already controls the grouping by deciding what to stage before the run. A heuristic split-by-subdirectory was considered and rejected as YAGNI: same lens as the brainstorm's *2026-05-19 Addendum — `--diverge` dropped*.
+
+### 5b. Commit
+
+Write the commit message to a temp file and pass via `-F`:
+
+```bash
+COMMIT_MSG_FILE=$(mktemp "${TMPDIR:-/tmp}/ba-propose-commit.XXXXXX")
+cat > "$COMMIT_MSG_FILE" <<'__BA_PROPOSE_COMMIT_END__'
+<title>
+
+<commit body — same content as PR/MR body>
+__BA_PROPOSE_COMMIT_END__
+
+git commit -F "$COMMIT_MSG_FILE"
+```
+
+The quoted sentinel `'__BA_PROPOSE_COMMIT_END__'` blocks `$VAR`, backticks, and literal `EOF` expansion.
+
+**Hook failure recovery.** If `git commit` returns non-zero:
+
+- Print the hook output verbatim.
+- Leave the working tree exactly as the hook left it.
+- Exit with message: "Hook failed — fix the reported issue and re-run `/ba:propose`. Composition outputs are deterministic; re-running re-derives them. Never re-run with `--no-verify` unless you've audited the hook and have an explicit reason."
+- Do NOT pass `--no-verify`. Never.
+
+### 5c. Push
+
+```bash
+git push -u origin HEAD
+```
+
+If push fails with non-fast-forward (rejected for `non-fast-forward` or `protected`):
+
+```bash
+git fetch origin "$BRANCH_NAME"
+git rev-list --left-right --count "origin/$BRANCH_NAME...HEAD"
+```
+
+Ask the user:
+
+> "Upstream `origin/<branch>` has commits not in your local branch. Force-pushing would discard them."
+>
+> 1. **Force-with-lease** — `git push --force-with-lease origin HEAD` (safe re-write; aborts if upstream changed since last fetch)
+> 2. **Abort** — leave the push undone; investigate manually
+
+Never `git push --force` without lease. Never silent.
+
+### 5d. Create or edit PR/MR
+
+If `HOST=unknown`:
+
+- Skip this step.
+- Print: "Host `<URL>` not supported by `ba:propose`. Composed body:" followed by the body.
+- Print: "Paste into your platform's UI manually. Commits were pushed successfully."
+- Exit zero (commit + push succeeded).
+
+Otherwise, check for existing open PR/MR:
+
+```bash
+# GitHub
+EXISTING_PR_URL=$(gh pr view --json url,state -q 'select(.state=="OPEN") | .url' 2>/dev/null)
+
+# GitLab
+EXISTING_MR_URL=$(glab mr view -F json 2>/dev/null | jq -r 'select(.state=="opened") | .web_url')
+```
+
+**Fetch-before-write** (when editing — close the BugBot-edit race window without a hash compare):
+
+```bash
+# Re-fetch body immediately before publish; re-extract preserved blocks from the now-current remote body
+CURRENT_BODY=$(gh pr view --json body -q .body)
+# (re-run the Step 2d extract on $CURRENT_BODY → fresh preserved_blocks tuple)
+```
+
+If the re-extracted preserved blocks differ from what Step 2d captured (the preview showed earlier), splice the *current* extract into the body being written. The preview may have shown a stale block; the published body always uses the freshest remote read. This costs one extra `gh pr view` call and ~5 lines of plan; in exchange we drop the hash capture, the three-way recovery menu, and one full re-loop through Steps 2d/3/4.
+
+The earlier-considered sha256 staleness check + interactive re-fetch/apply-anyway/abort menu was simplified out per the *2026-05-19 plan review* (same YAGNI lens as `--diverge`): preserved blocks are byte-identical by construction, so re-extracting from the latest remote read is sufficient — no comparison logic needed.
+
+**Write body to temp file** (always — no `--body "$(cat ...)"`, no stdin, no pipes):
+
+```bash
+BODY_FILE=$(mktemp "${TMPDIR:-/tmp}/ba-propose-body.XXXXXX")
+cat > "$BODY_FILE" <<'__BA_PROPOSE_BODY_END__'
+<full PR/MR body — same content as commit message>
+__BA_PROPOSE_BODY_END__
+```
+
+**Dispatch:**
+
+```bash
+# GitHub — create
+gh pr create \
+  --title "<title>" \
+  --body-file "$BODY_FILE" \
+  --base "$DEFAULT_BRANCH"
+
+# GitHub — edit existing
+gh pr edit "$EXISTING_PR_URL" \
+  --title "<title>" \
+  --body-file "$BODY_FILE"
+
+# GitLab — create
+glab mr create \
+  --title "<title>" \
+  --description-file "$BODY_FILE" \
+  --target-branch "$DEFAULT_BRANCH"
+
+# GitLab — edit existing
+glab mr update "$EXISTING_MR_URL" \
+  --title "<title>" \
+  --description-file "$BODY_FILE"
+```
+
+**Post-push PR-create failure.** If push succeeded in 5c but the `gh pr create` / `glab mr create` call fails:
+
+- Surface the platform's exact error message.
+- Print: "Push succeeded; PR/MR creation failed. Re-run `/ba:propose` after fixing the platform issue — commits are already pushed, so staging/commit/push are no-ops, and Step 5d will create the PR."
+- Exit non-zero. Do not retry automatically. Do not rewind the push.
+
+### 5e. Output
+
+On success, print:
+
+```
+✓ <title>
+  <PR or MR URL>
+```
+
+## Failure Modes
+
+| Failure | Where it surfaces | Recovery |
+|---|---|---|
+| Invalid branch state (detached HEAD, default branch with or without work) | Step 1 | Interactive routing per Step 1's four-way decision table — offer create-branch or refuse. |
+| `HOST=unknown` | Step 0a | Skip 5d; commit + push only; print body for manual paste. |
+| Empty diff (base moved) | Step 2a | `CompositionInputError` with rebase-or-close message. |
+| Linear MCP failure with ID present | Step 2b | Warn at preview; fall back to diff-derived motivation. |
+| Preserved-block race window | Step 5d | Re-fetch + re-extract immediately before publish; published body uses the freshest remote read. No interactive recovery needed. |
+| Body > 150 lines | Step 4 | Warn at preview; user decides. |
+| Hook failure on commit | Step 5b | Surface output, exit, never `--no-verify`. |
+| Non-fast-forward push | Step 5c | Offer `--force-with-lease` or abort. |
+| PR-create after-push fails | Step 5d | Surface error; instruct user to re-run `/ba:propose` (commits already pushed, so 5a-5c are no-ops, 5d retries the create). |
+
+## Important Guidelines
+
+- Composition is a pure contract — it consumes the value objects in `CompositionInputs` and reaches out to nothing. Add I/O? Add it to Step 2.
+- Never `git add -A` / `git add .`. Explicit paths only.
+- Never `--no-verify` unless the user has explicitly asked, with an audited reason.
+- Never silent force-push. `--force-with-lease` only, with explicit confirmation.
+- `--body-file` always points at a temp file written by a quoted-sentinel heredoc. Never `--body "$(cat ...)"`, never stdin, never pipes.
+- Preserved blocks (`<!-- CURSOR_SUMMARY -->`, `## Demo`, `## Screenshots`) are byte-identical in and out.
+- Linear is optional. Failure ≠ absence — warn at preview when MCP failed.
+- `docs/solutions/` absence is normal. Defensive empty-tuple.
+- The diff is visible on the platform; the body explains what the diff cannot show.
+- Title = effect, not mechanism. Rewrite if drafted as mechanism, disclose the rewrite in preview.
+- `fix:` over `feat:` when ambiguous.
+````
+
+#### Success Criteria
+
+##### Automated:
+- [ ] `grep '__BA_PROPOSE_BODY_END__\|__BA_PROPOSE_COMMIT_END__' commands/ba/propose.md` — quoted-sentinel heredoc markers present
+- [ ] `grep -c 'mktemp' commands/ba/propose.md` — temp-file pattern used (>= 2)
+- [ ] `grep 'force-with-lease' commands/ba/propose.md` — force-push policy present, no `--force` alone
+- [ ] `grep -E 'gh pr create|gh pr edit|glab mr create|glab mr update' commands/ba/propose.md` — all four host actions present
+- [ ] `grep '## Failure Modes' commands/ba/propose.md` — failure mode appendix present
+- [ ] `grep 'Hook failed' commands/ba/propose.md` — hook-failure recovery present
+- [ ] `grep -c 'AskUserQuestion' commands/ba/propose.md` — interactive prompts (final >= 12)
+- [ ] `commands/ba/propose.md` line count between 400 and 800 — in line with comparable commands
+
+##### Manual:
+- [ ] Preview block includes title, optional "rewritten from", line count, lead sentence, and warnings.
+- [ ] Edit-vs-create dispatch is conditional on `EXISTING_PR_URL` / `EXISTING_MR_URL`.
+- [ ] Step 5d re-fetches the PR body via `gh pr view --json body` (or `glab mr view`) and re-extracts preserved blocks from the freshest remote read immediately before publishing — no hash compare, no interactive menu.
+- [ ] Step 5a stages all changed files in a single commit using explicit paths only; no heuristic-based multi-commit grouping prompt.
+- [ ] `HOST=unknown` path completes commit + push but never invokes platform-specific create — falls through gracefully.
+- [ ] Post-push PR-create failure does not retry, does not rewind the push, and gives a clear `--describe-only` recovery path.
+
+> **Phase gate:** Automated verification must pass. Pause for manual verification before proceeding to Phase 5.
+
+---
+
+### Phase 5 — Docs updates and version bump
+
+Update `CLAUDE.md`, `README.md`, and `.claude-plugin/plugin.json` so the new command, new category, and new convention are documented in all three places per the established convention (`CLAUDE.md:74` — "Update README.md whenever commands, agents, or artifact paths are added or changed").
+
+#### Changes Required
+
+**File**: `CLAUDE.md`
+
+Insert a new `### Git workflow Commands` subsection between Knowledge (line 28) and `## Agents` (line 30). Verbatim block to insert at line 29:
+
+```markdown
+
+### Git Workflow Commands (ship code — commit, push, open PR/MR)
+
+- `/ba:propose [--describe-only] [--issue <ID>]` — Commit, push, and open PR/MR with a composed title and body
+```
+
+Append a new convention bullet at the end of `## Conventions` (currently `CLAUDE.md:74`):
+
+```markdown
+- Git workflow commands (`ba:propose`) commit, push, and open PR/MR — they never modify source files outside the staged diff
+```
+
+**File**: `README.md`
+
+Insert a new `### /ba:propose [args]` block at line 172 (immediately before `### Severity ladder and confidence anchors (/ba:review)`):
+
+```markdown
+### /ba:propose [--describe-only] [--issue <ID>]
+
+Commit, push, and open a PR/MR with a composed title and body.
+
+- Pure-function body composition: orchestrator gathers inputs (diff, branch, Linear, docs/solutions, preserved blocks, evidence) → composition reads value objects and returns title + body
+- Host-detected dispatch: GitHub `gh`, GitLab `glab`, graceful fallback for unknown hosts (compose + push only)
+- Body composition selects from Michael Lynch's 16-section menu, sized to the diff — the size-tier vocabulary is hidden behind the composition seam (no flag, no preview surface)
+- Linear MCP optional with diff-derived fallback; clear preview warning when MCP is unavailable
+- `docs/solutions/` auto-detection on current-branch-touched entries; per-entry confirm to splice as "What I learned"
+- Cursor BugBot block and existing `## Demo` / `## Screenshots` preserved byte-identical
+- Commit message and PR/MR body share the same composed markdown — no separate render path
+- `--body-file` discipline (temp file + quoted-sentinel heredoc); no `git add -A`/`.`; no `--no-verify`; `--force-with-lease` only
+- Preview-then-confirm always — apply / edit / regenerate-with-hint / exit
+```
+
+**File**: `.claude-plugin/plugin.json`
+
+Bump version, extend description, add keyword.
+
+Before:
+
+```json
+{
+  "name": "dev-workflow",
+  "version": "0.17.0",
+  "description": "Research, brainstorm, plan, slice, execute, review, and compound commands with triage, convention compliance, and knowledge compounding",
+  ...
+  "keywords": [
+    "research", "brainstorm", "planning", "slice", "execute",
+    "workflow", "conventions", "review", "compound", "knowledge"
+  ]
+}
+```
+
+After:
+
+```json
+{
+  "name": "dev-workflow",
+  "version": "0.18.0",
+  "description": "Research, brainstorm, plan, slice, execute, review, compound, and propose commands with triage, convention compliance, and knowledge compounding",
+  ...
+  "keywords": [
+    "research", "brainstorm", "planning", "slice", "execute",
+    "workflow", "conventions", "review", "compound", "knowledge", "propose"
+  ]
+}
+```
+
+#### Success Criteria
+
+##### Automated:
+- [ ] `grep 'Git Workflow Commands' CLAUDE.md` — new category present
+- [ ] `grep '/ba:propose' CLAUDE.md` — command listed in CLAUDE.md
+- [ ] `grep 'Git workflow commands.*never modify source files' CLAUDE.md` — convention bullet present
+- [ ] `grep '/ba:propose' README.md` — command listed in README
+- [ ] `grep -c 'force-with-lease\|--body-file' README.md` — discipline bullets visible to users (>= 1)
+- [ ] `grep '"version": "0.18.0"' .claude-plugin/plugin.json` — version bumped
+- [ ] `grep '"propose"' .claude-plugin/plugin.json` — keyword added
+- [ ] `grep '"description":.*propose' .claude-plugin/plugin.json` — description updated
+
+##### Manual:
+- [ ] CLAUDE.md `### Git Workflow Commands` section reads as a peer of the other category subsections, not a footnote.
+- [ ] README `### /ba:propose` block matches the style of `/ba:slice` and `/ba:compound` (one-line description + bullet list).
+- [ ] `plugin.json` version bump matches semver convention for a new command (`0.X.0` minor bump).
+- [ ] No accidental edits to `marketplace.json` (out of scope).
+- [ ] No accidental edits to `commands/ba/execute.md`'s "Create MR/PR" delegation — that menu may eventually point at `/ba:propose` but is out of scope here.
+
+> **Phase gate:** Automated verification must pass. Manual verification completes the plan.
+
+---
+
+## System-Wide Impact
+
+### Interaction Graph
+
+When `/ba:propose` runs in `full` mode:
+
+```
+user             →   /ba:propose
+orchestrator     →   git remote / git status / git rev-parse / git fetch / git diff / git log
+orchestrator     →   mcp__claude_ai_Linear__get_issue (optional)
+orchestrator     →   docs/solutions/ scan (file read)
+orchestrator     →   gh pr view --json url,state,body  /  glab mr view -F json (when existing PR)
+composition      ←   (returns title + body — no callouts)
+orchestrator     →   AskUserQuestion (preview confirm)
+orchestrator     →   git add <files>
+orchestrator     →   git commit -F <tempfile>  (triggers pre-commit, commit-msg hooks)
+orchestrator     →   git push -u origin HEAD  (triggers pre-push hook)
+orchestrator     →   gh pr create --body-file <tempfile>  /  glab mr create --description-file <tempfile>
+                     OR gh pr edit / glab mr update (when existing PR)
+```
+
+External callbacks affected: any pre-commit / commit-msg / pre-push hook the repo has installed. The command does not bypass them.
+
+### Error & Failure Propagation
+
+- Gather-side errors (Step 2) raise `CompositionInputError` — never reach composition.
+- Composition errors are not allowed by contract — it produces a valid body or it's a code bug to fix.
+- Apply-side errors (Step 5) surface verbatim to the user with explicit recovery instructions:
+  - Hook failure: working tree untouched, exit non-zero, user fixes and re-runs.
+  - Push rejection: explicit `--force-with-lease` confirmation, no silent override.
+  - PR-create failure after push success: separate `--describe-only` recovery flow documented.
+- MCP failure with ID present: warning bubbles to preview, no exception thrown.
+- `docs/solutions/` directory missing: defensive empty-tuple, silent.
+
+### State Lifecycle Risks
+
+The command makes mutations in this order: commit (local) → push (remote) → create/edit PR (remote). A failure between push and create-PR leaves a pushed branch with no PR — recovery is simply re-running `/ba:propose`: commits are already pushed, so 5a-5c are no-ops and 5d creates the PR. The fetch-before-write at the start of Step 5d ensures the freshest preserved blocks are spliced into the published body.
+
+No per-repo state file is written by `ba:propose`. Earlier drafts cached a `--diverge` answer in `.git/dev-workflow/propose-config`; that flag was dropped post-capture (see brainstorm: *2026-05-19 Addendum — `--diverge` dropped*) and the cache went with it.
+
+### API Surface Parity
+
+GitHub and GitLab adapters expose equivalent capability:
+
+| Operation | GitHub | GitLab |
+|---|---|---|
+| View open PR/MR | `gh pr view --json url,state,body,isDraft` | `glab mr view -F json` |
+| Create | `gh pr create --title <T> --body-file <F> --base <B>` | `glab mr create --title <T> --description-file <F> --target-branch <B>` |
+| Edit | `gh pr edit <URL> --title <T> --body-file <F>` | `glab mr update <URL> --title <T> --description-file <F>` |
+
+GHES uses `gh` with `GH_HOST` env. Self-hosted GitLab uses `glab` with its own config. Unknown hosts skip the create/edit step entirely.
+
+### Integration Test Scenarios
+
+Five cross-layer scenarios that unit-level greps would not catch:
+
+1. **GitHub feature branch, no existing PR, full workflow, no Linear, no solutions, no evidence.** Confirms minimal-input happy path produces a short body (composition-internal "small" tier; not named at call site) and `gh pr create --body-file` succeeds.
+2. **GitLab feature branch, existing open MR, BugBot block present, no new commits to push.** Step 0b detects the open MR + nothing-to-push and asks "update description only?" — on Yes, Step 5 skips push and Step 5d calls `glab mr update` (not `glab mr create`); BugBot block round-trips byte-identical.
+3. **Substantive change (>200 lines, >10 files) with multiple `docs/solutions/` hits, per-entry confirm.** Confirms per-entry AskUserQuestion, "include all"/"skip all" shortcuts, and that the composed body splices accepted entries as "What I learned" while dropping rejected ones.
+4. **Linear MCP unavailable (server stopped), branch name `bru/TO-123-fix-x`.** Confirms preview shows the "Linear MCP unavailable" warning, body uses diff-derived motivation, command does not error.
+5. **Unknown host (`git@bitbucket.org:org/repo.git`), feature branch, full workflow.** Confirms commit + push succeed, the create-PR step is skipped with the "paste manually" message, body is printed in full, exit code is zero.
+
+## Risk Analysis & Mitigation
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| `--body-file` discipline regresses (someone adds `--body "$(cat ...)"` in a future edit) | High | Automated grep in Success Criteria; explicit Important Guidelines bullet; the Failure Modes table singles it out. |
+| Composition seam leaks (orchestrator starts reading composition internals) | Medium | Locked design documented in Step 3; reviewers can flag drift. |
+| Preserved-block byte-identity breaks (a future composition tweak alters whitespace) | High | Step 3.6 explicitly says "raw markdown is inserted as-is — do not re-format"; success criterion includes BugBot round-trip behavior. |
+| MCP schema drift breaks Linear motivation | Low | `issue_context.raw: Mapping[str, Any]` is opaque — composition reads "whatever fields exist if available." |
+| `gh`/`glab` not installed | Medium | Detection failure in Step 0a leads to `HOST=unknown` path; no hard dependency assertion. |
+| Hook bypass via accident | High | Explicit "never `--no-verify`" rule; Failure Modes recovery is fix-and-retry, never bypass. |
+| Force-push catastrophic | High | Only `--force-with-lease`, only after explicit AskUserQuestion confirmation. |
+| Title rewrite changes intent silently | Medium | Always disclose `rewritten from: <original>` in preview when a rewrite occurred. |
+| Body too long without warning | Low | Soft cap warning at preview; user decides. |
+
+## Testing Strategy
+
+This repo has no test harness — verification is structural greps + manual scenario walk-throughs (see `docs/plans/2026-03-14-feat-add-ba-execute-command-plan.md` for the canonical precedent). The `Success Criteria` per phase above codifies both.
+
+**Manual scenario coverage** corresponds 1:1 to the five Integration Test Scenarios above. Each can be exercised by running `/ba:propose` against a real branch with the relevant repo configuration. The author should run all five before tagging v0.18.0.
+
+**Convention-checker re-run** (already done at plan capture; success criteria covers the conventions the plan introduces).
+
+## Documentation Plan
+
+- `commands/ba/propose.md` — new, ~500–700 LoC, the command itself.
+- `CLAUDE.md` — new category subsection + new convention bullet.
+- `README.md` — new `### /ba:propose` block.
+- `.claude-plugin/plugin.json` — version + description + keywords.
+
+Not in this plan:
+- `marketplace.json` bump (separate cadence).
+- `docs/solutions/` seeding (handled organically by `/ba:compound` after first usage).
+- Roadmap `✅` (added post-release if at all).
+
+## Dependencies & Risks
+
+**External CLIs required at runtime:**
+- `gh` — GitHub CLI. Installation: `brew install gh` / `apt install gh`. Authentication: `gh auth login`.
+- `glab` — GitLab CLI. Installation: `brew install glab`. Authentication: `glab auth login`.
+
+**Optional MCP server:**
+- Linear MCP (`mcp__claude_ai_Linear__*`). Absence is silently tolerated; presence is auto-detected.
+
+**Risks tracked above** in *Risk Analysis & Mitigation*.
+
+## Sources & References
+
+### Origin
+
+- Brainstorm: `docs/brainstorms/2026-05-19-ba-propose-shipping-skill-brainstorm.md`. Key decisions carried forward:
+  - Command name `ba:propose` and new "Git workflow" category (see brainstorm: `## Key Decisions`).
+  - Hybrid Locked Design — A's pure-function composition + C's opaque value-object inputs (see brainstorm: `## Locked Design`).
+  - Acceptance criteria items 1–11 (see brainstorm: `## Acceptance Criteria`).
+  - Scope boundaries (see brainstorm: `## Scope Boundaries`).
+  - Carry-over from CE: mode dispatch, four-way branch tree, file-level commit splitting, `--body-file` discipline, preview-apply summary, `fix:` vs `feat:`, `#`-list-prefix gotcha (see brainstorm: `## Key Decisions`).
+  - Carry-over from `mr` skill: Linear MCP optional, BugBot preservation, Lynch effect-vs-mechanism worked example.
+  - Drops from `mr`: fixed 3-heading template, hardcoded `time-off` scope, 50-char title cap, GitLab-only orientation.
+
+### Internal References
+
+- Existing command file structures: `commands/ba/execute.md`, `commands/ba/review.md`, `commands/ba/compound.md`, `commands/ba/plan.md`.
+- Existing `gh`/`glab` usage precedent (read-only): `commands/ba/review.md:76-86`.
+- Existing `--body-file` precedent (issue creation): `commands/ba/plan.md:507`.
+- Existing `docs/solutions/` defensive pattern: `commands/ba/compound.md:55-61`.
+- Existing test-strategy precedent: `docs/plans/2026-03-14-feat-add-ba-execute-command-plan.md:459-482`.
+- Standing synthesis-lock rule: `docs/brainstorms/2026-05-02-ousterhout-principles-roadmap-brainstorm.md` *### Concrete rules*.
+
+### External References
+
+- Michael Lynch, *How to Write Useful Commit Messages* — `https://refactoringenglish.com/chapters/commit-messages/` (extracted in `docs/research/2026-05-17-shipping-skill-source-material-research.md` Source 4).
+- EveryInc `ce-commit-push-pr` skill — extracted in `docs/research/2026-05-17-shipping-skill-source-material-research.md` Source 1.
+- Local `mr` skill — `~/.claude/skills/mr/SKILL.md` (Bruno's machine; reference only).
+- Cursor BugBot sentinel format — extracted in `docs/research/2026-05-17-shipping-skill-source-material-research.md` Source 5.
+
+## Convention Compliance
+
+- [x] Filename matches `YYYY-MM-DD-<type>-<name>-plan.md` — `2026-05-19-feat-add-ba-propose-command-plan.md`
+- [x] YAML frontmatter present with `title`, `type`, `status`, `date`, `origin`, `detail_level`, `iteration_count`, `tags`
+- [x] Plan does not write source code — only specifies markdown command file + doc updates
+- [x] Command prefix `ba:` honored
+- [x] `What We're NOT Doing` section present
+- [x] Per-phase Success Criteria separated into Automated and Manual
+- [x] Phase gates pause for manual verification before next phase
+- [x] Exact file paths and concrete code blocks used (no placeholder pseudo-paths)
+- [x] CLAUDE.md `## Conventions` update planned (Phase 5)
+- [x] README.md update planned (Phase 5)
+- [x] `version` bump in `.claude-plugin/plugin.json` planned (Phase 5)
+- [x] Composition-spec Python signatures retained as design contract — template-sanctioned per the brainstorm's design-it-twice template (see brainstorm: `## Convention Compliance`, *Informational*)
+- [x] New "Git workflow" command category added to CLAUDE.md per brainstorm's Convention Compliance directive
+- [x] Origin brainstorm reference present in frontmatter and Sources
+- [x] All built-in reviewers / protected-artifact rules unaffected by this plan
+</script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/marked/4.3.0/marked.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
+<script>
+(function() {
+  const raw = document.getElementById('md').textContent;
+
+  // Parse YAML-ish frontmatter (simple key: value lines)
+  const fmMatch = raw.match(/^\s*---\n([\s\S]*?)\n---\n([\s\S]*)$/);
+  let metadata = {};
+  let body = raw;
+  if (fmMatch) {
+    body = fmMatch[2];
+    fmMatch[1].split('\n').forEach(line => {
+      const m = line.match(/^(\w+):\s*(.*)$/);
+      if (m) metadata[m[1]] = m[2].replace(/^["']|["']$/g, '');
+    });
+  }
+
+  marked.setOptions({ gfm: true, headerIds: true, mangle: false, breaks: false });
+
+  const content = document.getElementById('content');
+  content.innerHTML = renderMetadata(metadata) + marked.parse(body);
+  document.title = (metadata.title || 'Plan') + ' — Plan';
+
+  // Syntax highlight
+  content.querySelectorAll('pre code').forEach(el => {
+    try { hljs.highlightElement(el); } catch (e) {}
+  });
+
+  // Phase-gate blockquotes
+  content.querySelectorAll('blockquote').forEach(b => {
+    if (/Phase gate/i.test(b.textContent)) b.classList.add('phase-gate');
+  });
+
+  // Hover anchor links on headings
+  content.querySelectorAll('h1[id], h2[id], h3[id], h4[id], h5[id]').forEach(h => {
+    const a = document.createElement('a');
+    a.href = '#' + h.id;
+    a.className = 'anchor';
+    a.textContent = '#';
+    a.setAttribute('aria-label', 'Anchor');
+    h.appendChild(a);
+  });
+
+  // Build TOC from h2 / h3 / h4 (skip Implementation Phases h4 noise — keep h4 only under specific h2s)
+  const toc = document.getElementById('toc');
+  const headingsForToc = content.querySelectorAll('h2[id], h3[id]');
+  headingsForToc.forEach(h => {
+    const li = document.createElement('li');
+    li.className = 'depth-' + h.tagName[1];
+    const a = document.createElement('a');
+    a.href = '#' + h.id;
+    // Strip the trailing # anchor text from heading title
+    const clone = h.cloneNode(true);
+    clone.querySelectorAll('.anchor').forEach(el => el.remove());
+    a.textContent = clone.textContent.trim();
+    li.appendChild(a);
+    toc.appendChild(li);
+  });
+
+  // Scrollspy — highlight active TOC entry as user scrolls
+  const tocLinks = toc.querySelectorAll('a');
+  const observed = content.querySelectorAll('h2[id], h3[id]');
+  const visibleIds = new Set();
+  const observer = new IntersectionObserver(entries => {
+    entries.forEach(e => {
+      if (e.isIntersecting) visibleIds.add(e.target.id);
+      else visibleIds.delete(e.target.id);
+    });
+    // Pick the first visible id by document order
+    let activeId = null;
+    for (const h of observed) {
+      if (visibleIds.has(h.id)) { activeId = h.id; break; }
+    }
+    tocLinks.forEach(l => l.classList.toggle('active', activeId && l.getAttribute('href') === '#' + activeId));
+  }, { rootMargin: '-12% 0px -75% 0px', threshold: 0 });
+  observed.forEach(h => observer.observe(h));
+
+  function renderMetadata(meta) {
+    if (!Object.keys(meta).length) return '';
+    const pills = [];
+    const order = ['type', 'status', 'date', 'detail_level', 'iteration_count'];
+    order.forEach(k => {
+      if (meta[k]) pills.push('<span class="pill">' + k.replace('_', ' ') + ': <strong>' + escapeHtml(meta[k]) + '</strong></span>');
+    });
+    if (meta.origin) {
+      const rel = meta.origin.replace(/^docs\//, '../../');
+      pills.push('<span class="pill">origin: <a href="' + escapeAttr(rel) + '" target="_blank">brainstorm</a></span>');
+    }
+    return '<div class="meta-bar">' + pills.join('') + '</div>';
+  }
+
+  function escapeHtml(s) {
+    return String(s).replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
+  }
+  function escapeAttr(s) { return escapeHtml(s); }
+})();
+</script>
+</body>
+</html>

--- a/docs/plans/2026-05-19-feat-add-ba-propose-command-plan.md
+++ b/docs/plans/2026-05-19-feat-add-ba-propose-command-plan.md
@@ -1,0 +1,1063 @@
+---
+title: "feat: Add ba:propose Shipping Command"
+type: feat
+status: active
+date: 2026-05-19
+origin: docs/brainstorms/2026-05-19-ba-propose-shipping-skill-brainstorm.md
+detail_level: comprehensive
+iteration_count: 1
+tags: [command, ba-propose, git-workflow, commit, pull-request, merge-request, body-composition]
+---
+
+# Add `ba:propose` Shipping Command — Implementation Plan
+
+## Overview
+
+Add a new `ba:propose` command to the `dev-workflow` plugin that commits, pushes, and opens a PR/MR with a composed title and body. The command introduces a new **Git workflow** command category alongside Research / Planning / Execution / Quality / Knowledge, and is the first command in the repo that issues `gh pr create` / `glab mr create` itself (existing `/ba:execute` delegates the act).
+
+The high-level design is locked at the brainstorm (see brainstorm: `docs/brainstorms/2026-05-19-ba-propose-shipping-skill-brainstorm.md` — *Locked Design*). The plan's job is to translate that design into the concrete command-markdown structure, document set, and version bump that ship `ba:propose` to v0.18.0.
+
+## Current State
+
+- **Command files** all live in `commands/ba/*.md` as self-contained markdown (8 files, 164–821 LoC each). `commands/ba/execute.md:419-437` already has a "Create MR/PR" completion menu that delegates to the user; `ba:propose` replaces that delegation with a concrete command.
+- **No existing command issues `gh pr create` / `glab mr create`.** Existing `gh`/`glab` usage is read-only — `commands/ba/review.md:76-86` invokes `gh pr diff`, `gh pr view`, `glab mr diff`, `glab mr view`.
+- **No `--body-file` heredoc precedent in the repo.** `commands/ba/plan.md:507` uses `gh issue create --title <t> --body-file <plan_path>` but that's the only existing `--body-file` usage, and it's for issues, not PRs. `ba:propose` establishes the multi-paragraph PR-body discipline for the first time.
+- **`docs/solutions/` directory does not yet exist** anywhere in the repo. `commands/ba/compound.md:55-61` already includes defensive handling ("If the directory doesn't exist or is empty, return 'No existing docs found'"); `ba:propose` follows the same defensive pattern.
+- **No Linear MCP integration precedent.** `commands/ba/plan.md:497-508` mentions Linear only as a tracker CLI (`linear issue create ...`), not as an MCP source. `ba:propose` establishes the optional-MCP-with-graceful-fallback pattern.
+- **Plugin version is `0.17.0`** at `.claude-plugin/plugin.json:3`. Marketplace version at `.claude-plugin/marketplace.json:11` is `0.1.0` (stale, not bumped per release historically — not in scope here).
+- **CLAUDE.md `## Commands` section** has five subsections — Research / Planning / Execution / Quality / Knowledge (`CLAUDE.md:5-28`). New "Git workflow" subsection lands between Knowledge and `## Agents` at line 29.
+- **README `## Commands` section** is flat — no subsection headings, each command has its own `### /ba:xxx` block (`README.md:36-197`). New `/ba:propose` block lands before `### Severity ladder…` at line 172.
+- **CE four-way branch decision tree, Lynch's 16-section menu, `--body-file` heredoc recipe, BugBot sentinel** all extracted verbatim in `docs/research/2026-05-17-shipping-skill-source-material-research.md`. (Squash-merge detection was also extracted but is no longer used — see brainstorm: *2026-05-19 Addendum — `--diverge` dropped*.)
+- **`docs/brainstorms/2026-05-02-ousterhout-principles-roadmap-brainstorm.md` `### Concrete rules`** is the standing synthesis-lock authority cited by the brainstorm (brainstorm line 157). Plan must respect the lock — refine, do not re-add rejected elements.
+
+## What We're NOT Doing
+
+- **Not writing Python code.** The locked design's `compose_body(inputs) -> ComposedBody` is a logical specification Claude executes from the command markdown — not an importable function (see brainstorm: `## Convention Compliance`, *Informational*). Type signatures stay as design contracts.
+- **Not creating `docs/solutions/`** as part of this rollout. Defer to first `/ba:compound` run.
+- **Not creating a sub-agent for body composition.** Composition is inlined as a clearly-delimited spec section in `commands/ba/propose.md`. Extracting to `agents/workflow/body-composer.md` later is a future plan if the spec grows past ~300 LoC of internal complexity.
+- **Not creating a `references/` directory pattern.** No existing command in the repo splits into helper markdown; `propose.md` is a single self-contained file like every other.
+- **Not implementing automated evidence capture** (CE's `ce-demo-reel`). Evidence is user-supplied URLs only.
+- **Not adding auto-`/ba:review` chaining.** User decides when to run review.
+- **Not handling deploy, merge, or auto-approve.** The command does three things: commit, push, open PR/MR.
+- **Not bumping `marketplace.json`.** Out of scope; not a per-command convention.
+- **Not adding a `--diverge` flag** for commit-vs-PR-body divergence (see brainstorm: *2026-05-19 Addendum — `--diverge` dropped*). The aligned-default plus the preview's Edit affordance handle ad-hoc divergence; the brainstorm's own rejection of Design B's `overrides` (YAGNI) applies here too.
+- **Not adding a roadmap entry** before release. Roadmap line gets `✅` after release if added at all.
+- **Not updating `commands/ba/execute.md`'s "Create MR/PR" completion menu** (currently `execute.md:419-437`) to point at `/ba:propose`. Out of scope for v0.18.0 to avoid blast-radius coupling between commands; tracked as [azevedo/dev-workflow#13](https://github.com/azevedo/dev-workflow/issues/13).
+
+## Behaviors to Test
+
+User-observable behaviors `ba:propose` must satisfy. Authored once here; serves scope, review, and test-coverage simultaneously. Each line is one structural grep or one manual scenario.
+
+- [ ] On a feature branch with new commits, running `/ba:propose` previews a title and body, then on confirmation pushes commits and opens a PR/MR.
+- [ ] Title is effect-phrased — when composition rewrites a mechanism-only title, the preview shows `Title: <effect-phrased>  (rewritten from: <original>)`.
+- [ ] When the remote host is `github.com` (or a GHES host inferred from remote URL), the command invokes `gh pr create --body-file <path>`.
+- [ ] When the remote host is `gitlab.com` (or a self-hosted GitLab), the command invokes `glab mr create --description-file <path>`.
+- [ ] When the remote host is neither GitHub nor GitLab, the command completes commit + push, prints the composed body, and tells the user the platform isn't supported — without ever calling `gh pr create` / `glab mr create`.
+- [ ] Cursor BugBot block (`<!-- CURSOR_SUMMARY --> … <!-- /CURSOR_SUMMARY -->`) is preserved byte-identical when rewriting an existing PR/MR description.
+- [ ] Existing `## Demo` and `## Screenshots` blocks are preserved byte-identical when rewriting an existing PR/MR description.
+- [ ] When a Linear issue ID is detected (supplied as arg or parsed from branch name) and the Linear MCP server responds, motivation is sourced from MCP.
+- [ ] When a Linear issue ID is detected but the Linear MCP server is unavailable, the preview shows a one-line warning ("Linear MCP unavailable — using diff-derived motivation") and the command continues without error.
+- [ ] When no Linear issue ID is present, the command never errors on missing Linear; motivation is derived from the diff and recent commits.
+- [ ] `docs/solutions/` entries touched on the current branch since the last merge to `origin/HEAD` are detected and presented one-by-one for inclusion confirmation; the user can accept any subset.
+- [ ] No `gh pr create` / `glab mr create` invocation uses `--body "$(cat ...)"`, stdin, pipes, or `--body-file -`. Every invocation uses `--body-file <temp_path>` (or `--description-file <temp_path>`) where `<temp_path>` was written by a quoted-sentinel heredoc.
+- [ ] Commit message and PR/MR body share the same composed markdown — no separate per-commit-vs-PR rendering path.
+- [ ] Staging uses explicit paths only — no `git add -A`, no `git add .` anywhere in the command's bash blocks.
+- [ ] No `--no-verify` flag is passed to `git commit` or `git push` anywhere.
+- [ ] On pre-commit / commit-msg hook failure, the command surfaces hook output, leaves the working tree intact, and exits with a clear "fix the hook and re-run" message — never with `--no-verify`.
+- [ ] `--describe-only` prints the composed body without committing or pushing; on a branch with no open PR/MR it composes and prints, returning zero.
+- [ ] When the command is run on a feature branch that has an open PR/MR, it switches to edit semantics (`gh pr edit --body-file` / `glab mr update --description-file`) instead of failing with "PR already exists."
+- [ ] Branch routing handles all four CE cases — detached HEAD, default branch with uncommitted work, default branch with no work, feature branch.
+- [ ] The command never issues a force-push silently; non-fast-forward push prompts the user to use `--force-with-lease` or abort.
+- [ ] Empty-diff (feature branch fully contained in base) raises a `CompositionInputError` with the message "branch is fully contained in base; rebase or close."
+- [ ] Preview-abort returns the user to a menu: edit body, regenerate with a one-line hint, or exit. The flow never silently exits or silently recomposes.
+- [ ] CLAUDE.md gains a new `### Git Workflow Commands` subsection and a new convention bullet; README gains a new `### /ba:propose` block.
+- [ ] `.claude-plugin/plugin.json` version is bumped to `0.18.0`, `description` includes "propose", and `keywords` array includes `"propose"`.
+
+## Proposed Solution
+
+Ship `ba:propose` as a single comprehensive command file `commands/ba/propose.md` containing:
+
+1. **Frontmatter** — `name: ba:propose`, instruction-to-Claude description, argument-hint covering `[--describe-only] [--issue <ID>]`.
+2. **Argument capture** — `<propose_args> #$ARGUMENTS </propose_args>` block following the established pattern (`commands/ba/execute.md:13`).
+3. **Orchestrator step sequence** — Step 0 (pre-flight: host + mode detection) → Step 1 (branch routing) → Step 2 (gather inputs) → Step 3 (compose body — the seam) → Step 4 (preview) → Step 5 (apply: commit, push, create-or-edit PR/MR).
+4. **Composition spec** — a clearly-delimited section that documents the `compose_body` contract: inputs, tier classifier, section selector, splicer, title rewriter, invariants. Claude executes this spec at runtime.
+5. **Failure modes** — explicit recovery flows for hook failure, push rejection, post-push PR-create failure, unknown host, MCP unavailability, preserved-block staleness, empty diff, body-too-large warning.
+
+Outside the command file, three documents update: `CLAUDE.md` (new category + convention bullet), `README.md` (new `### /ba:propose` block), `.claude-plugin/plugin.json` (version, description, keywords).
+
+## Technical Approach
+
+### Architecture
+
+```
+                  ┌─────────────────────────────────────────────────┐
+                  │  commands/ba/propose.md  (single-file command)  │
+                  └─────────────────────────────────────────────────┘
+                                          │
+        ┌─────────────────────────────────┼─────────────────────────────────┐
+        │                                 │                                 │
+        ▼                                 ▼                                 ▼
+   Orchestrator              Composition Spec (seam)          Platform Adapter
+   (gather inputs            (pure-function contract,         (host detection,
+   from git, MCP,            tier+section+splice+title,       gh/glab dispatch,
+   solutions, evidence)      no I/O reach-out)                heredoc-to-tempfile,
+                                                              create-or-edit)
+```
+
+- **Orchestrator** owns I/O — git, `gh repo view`, Linear MCP, `docs/solutions/` scan, preserved-block extraction, user-supplied evidence prompts.
+- **Composition spec** is pure; consumes only the value objects from `CompositionInputs`. Stateless, deterministic, idempotent. All editorial judgment lives here.
+- **Platform adapter** is a thin layer that handles host detection (parse `git remote get-url origin`), maps to `gh` or `glab` commands, applies the `--body-file` heredoc recipe, and detects "PR already exists" → switches to edit.
+
+This mirrors the brainstorm's locked design (see brainstorm: `## Locked Design`, *Dependency strategy*): pure composition + I/O-owning orchestrator + thin host adapter, no Linear/MCP/git knowledge inside composition.
+
+### Alternative Approaches Considered
+
+- **Composition as a sub-agent (`agents/workflow/body-composer.md`).** Rejected. The agent precedent is small (74–129 LoC) and single-purpose, but composition needs the same context the orchestrator has just gathered — making it a separate agent means re-passing all those inputs through a Task call, which is a serialization tax with no architectural payoff. The brainstorm's pure-function seam already gives the testability and swap-ability we need without crossing an agent boundary. A future plan can extract if internal complexity warrants.
+- **Two commands — `ba:commit` and `ba:open`.** Rejected. The brainstorm names `ba:propose` and resolves the namespace question (see brainstorm: `## Resolved Questions`, "Namespace"). Two commands also fragment the body — the same composed body should feed both commit and PR/MR by default.
+- **A `references/` directory pattern** — separating composition spec from orchestrator narrative. Rejected. No repo precedent; CLAUDE.md convention update would be required; single-file precedent is robust and reviewable.
+- **Embedding the spec as a sub-document at `commands/ba/propose/composition.md`.** Same rejection rationale — net-new convention, no payoff over a section heading inside the main file.
+- **Auto-creating `docs/solutions/`** as part of this plan. Rejected. The brainstorm doesn't require it, and `commands/ba/compound.md:56` already documents the "directory absent → return 'no docs found'" defensive pattern; `ba:propose` follows the same pattern. Pre-creating the directory introduces noise without benefit.
+
+## Implementation Phases
+
+### Phase 1 — Command scaffold, frontmatter, mode dispatch, branch routing
+
+Lay down `commands/ba/propose.md` with the frontmatter, argument capture, mode-dispatch logic, host detection, and branch-routing decision tree. No body composition yet — Phase 1 ends with a command that can identify what mode it's in, detect the host, route correctly across the four CE branch states, and refuse cleanly on unsupported hosts or detached HEAD.
+
+#### Changes Required
+
+**File**: `commands/ba/propose.md` (new file)
+
+````markdown
+---
+name: ba:propose
+description: Commit, push, and open a PR/MR with a composed title and body — preview-then-confirm, host-detected dispatch for GitHub and GitLab.
+argument-hint: "[--describe-only] [--issue <ID>] [optional: free-text hint]"
+---
+
+# Propose Changes for Review
+
+Compose a commit and PR/MR body that helps the code reviewer first, teammates and future-bug-investigators next.
+
+## Arguments
+
+<propose_args> #$ARGUMENTS </propose_args>
+
+### Parse Arguments
+
+Strip recognized flags from the argument string; what remains is a free-text hint that the user wants reflected in motivation.
+
+Recognized flags:
+
+- `--describe-only` — Compose and print the body; do not commit, push, or create/edit a PR/MR. Useful as a dry run.
+- `--issue <ID>` — Explicitly bind a Linear issue ID. Overrides branch-name detection.
+
+Note: there is no explicit `--describe-update` flag. When the command is run on a feature branch with an existing open PR/MR, Steps 2d and 5d auto-detect the open PR and switch to edit semantics (`gh pr edit` / `glab mr update`) without requiring a mode flag. If the user is on a branch with no new commits to push *and* an open PR exists, Step 0b asks whether to update the PR description only — the answer drives the same code path. One flag, one auto-detection — no parallel surface.
+
+## Step 0: Pre-flight
+
+### 0a. Detect remote host
+
+```bash
+REMOTE_URL=$(git remote get-url origin 2>/dev/null || echo "")
+```
+
+Parse `REMOTE_URL` to classify:
+
+- Matches `github.com` → `HOST=github`, `CLI=gh`.
+- Matches `gitlab.com` → `HOST=gitlab`, `CLI=glab`.
+- Else parse the host from the remote URL and probe (in order):
+  - If `$GH_HOST` is already set in the environment AND matches the parsed host → `HOST=ghes`, `CLI=gh`.
+  - Else attempt `gh api /meta --hostname <parsed_host> 2>/dev/null`. Success (returns a JSON object with `github_services_sha`) → `HOST=ghes`, `CLI=gh`, `export GH_HOST=<parsed_host>`.
+  - Else attempt `glab config get -g host` and check whether the parsed host is registered. Match → `HOST=gitlab-self`, `CLI=glab`.
+  - All probes failed → `HOST=unknown`.
+- No remote at all → `HOST=unknown`.
+
+If `HOST=unknown`, announce: "Remote `<URL>` is not GitHub or GitLab. `ba:propose` will still commit and push, but cannot open the PR/MR — paste the composed body into your platform's web UI when prompted."
+
+### 0b. Detect mode
+
+```bash
+MODE=full
+[[ "$ARGS" == *--describe-only* ]] && MODE=describe-only
+```
+
+If `MODE=full` AND `git rev-list @{upstream}..HEAD 2>/dev/null` returns empty (nothing to push) AND an open PR/MR exists for the branch, ask:
+
+> "Nothing to push. Update the PR description only?"
+>
+> 1. **Yes** — skip commit/push, proceed to Step 5d which auto-detects the open PR and edits it
+> 2. **No** — exit (nothing to do)
+
+A `Yes` answer sets an internal `skip_push = True` orchestrator flag. Step 5 reads this flag and skips Steps 5a-5c; Step 5d runs as normal and finds the existing PR via `gh pr view` / `glab mr view`, dispatching to `gh pr edit` / `glab mr update`.
+
+## Step 1: Branch routing
+
+```bash
+git status --porcelain=v2 --branch
+git rev-parse --abbrev-ref HEAD
+```
+
+Detect branch state and route per CE's four-way decision tree (see `docs/research/2026-05-17-shipping-skill-source-material-research.md` *Branch routing*):
+
+| State | Behavior |
+|---|---|
+| Detached HEAD | Ask: "Detached HEAD — create a feature branch from these commits? Suggested name: `<derived-from-diff>`." If yes, `git checkout -b <name>` and continue. If no, refuse. |
+| Default branch with uncommitted work | Ask: "You're on `<default>` with uncommitted work. Create a feature branch? Suggested name: `<derived-from-diff>`." If yes, `git checkout -b <name>` and continue. If no, refuse. |
+| Default branch with no work | Refuse: "On `<default>` with nothing to propose. Switch to a feature branch first." |
+| Feature branch | Continue. |
+
+**Default-branch detection** (used above):
+
+```bash
+DEFAULT_BRANCH=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's@^origin/@@')
+[[ -z "$DEFAULT_BRANCH" ]] && DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name 2>/dev/null)
+[[ -z "$DEFAULT_BRANCH" ]] && DEFAULT_BRANCH=$(git remote show origin 2>/dev/null | awk '/HEAD branch/ {print $NF}')
+```
+
+If still empty, ask the user.
+
+## Step 2: … (continued in Phase 2)
+````
+
+#### Success Criteria
+
+##### Automated:
+- [ ] `ls commands/ba/propose.md` — file exists
+- [ ] `head -5 commands/ba/propose.md` — frontmatter starts with `name: ba:propose`
+- [ ] `grep -c '#\$ARGUMENTS' commands/ba/propose.md` — argument capture present (>= 1)
+- [ ] `grep -c 'AskUserQuestion' commands/ba/propose.md` — interactive prompts present (>= 5 by end of plan)
+- [ ] `grep -c '^## Step ' commands/ba/propose.md` — step structure present (>= 1 after Phase 1; >= 6 after Phase 5)
+- [ ] `grep -E 'git add -A|git add \.' commands/ba/propose.md` — returns empty (no bulk staging)
+- [ ] `grep '\--no-verify' commands/ba/propose.md` — returns empty (no hook bypass)
+- [ ] `grep 'github.com\|gitlab.com' commands/ba/propose.md` — both hosts referenced
+- [ ] `grep 'Detached HEAD\|default branch' commands/ba/propose.md` — all four branch states mentioned
+
+##### Manual:
+- [ ] Frontmatter matches the universal command shape (`name`, `description`, `argument-hint`).
+- [ ] Prose voice is instruction-to-Claude (imperative, "Run …", "Ask …") — matching `commands/ba/execute.md` and `commands/ba/review.md`.
+- [ ] Host-detection branch enumerates GHES and self-hosted GitLab explicitly, with a graceful unknown-host path.
+
+> **Phase gate:** Automated verification must pass. Pause for manual verification before proceeding to Phase 2.
+
+---
+
+### Phase 2 — Input gathering (diff, branch, Linear, solutions, preserved blocks, evidence)
+
+Add Step 2 to the command file: the orchestrator's input-gathering steps that materialize `CompositionInputs` for the composition seam. Linear MCP optional with explicit failure-vs-absence distinction; `docs/solutions/` scan with per-entry confirmation; preserved-block extraction from existing PR body (re-extracted at apply time in Step 5d to close the BugBot-edit race window without explicit hash compare); evidence prompt.
+
+#### Changes Required
+
+**File**: `commands/ba/propose.md` (append Step 2)
+
+````markdown
+## Step 2: Gather inputs
+
+Each sub-step materializes one field of `CompositionInputs`. None of this happens inside composition.
+
+### 2a. Diff and branch metadata
+
+```bash
+git fetch --no-tags origin "$DEFAULT_BRANCH"
+DIFF_BASE=$(git merge-base HEAD "origin/$DEFAULT_BRANCH")
+git diff --stat "$DIFF_BASE..HEAD"
+git diff --numstat "$DIFF_BASE..HEAD"
+git log --pretty=oneline "$DIFF_BASE..HEAD"
+git rev-parse --abbrev-ref HEAD
+```
+
+Capture into the orchestrator's local state:
+
+- `diff.range = "$DIFF_BASE..HEAD"`
+- `diff.file_stats = <output of --numstat>`
+- `diff.commit_log = <output of --pretty=oneline>`
+- `branch.name = <current branch>`
+- `branch.base_ref = "origin/$DEFAULT_BRANCH"`
+- `branch.last_merge_sha = "$DIFF_BASE"`
+
+If `git diff --stat "$DIFF_BASE..HEAD"` is empty AND there are commits in the log, raise the empty-diff error:
+
+> **CompositionInputError: branch is fully contained in base.**
+> Your commits exist but the diff vs `<DEFAULT_BRANCH>` is empty. Likely causes: someone landed equivalent changes in `<DEFAULT_BRANCH>` and your branch is now redundant, or the base was force-pushed past your branch tip. Rebase, or close the branch.
+
+If `git diff --stat` is non-empty but unreadable (returns non-zero with no diff), raise:
+
+> **CompositionInputError: diff unreadable.**
+> `git diff $DIFF_BASE..HEAD` returned non-zero. Check the repository state.
+
+### 2b. Linear issue context (optional)
+
+Determine the issue ID:
+
+1. If `--issue <ID>` was passed, use it.
+2. Else, regex-extract from branch name: `[A-Z]{2,5}-[0-9]+` (e.g., `bru/TO-1234-fix-x` → `TO-1234`).
+3. Else, no issue ID — skip MCP entirely, `issue_context = None`.
+
+If an ID is present, attempt the MCP call:
+
+```
+mcp__claude_ai_Linear__get_issue(id: <ID>)
+```
+
+- **Success** → `issue_context = IssueContext(raw=<mcp response>)`. Composition reads whatever fields it needs.
+- **Failure** (MCP not installed, server down, auth expired, ID not found) → `issue_context = None`, AND record `mcp_unavailable = True` so the preview can surface a warning: "Linear MCP unavailable — using diff-derived motivation."
+
+The orchestrator never raises on MCP failure. Linear is optional.
+
+`mcp_unavailable` is **orchestrator-side state only** — it lives in the run-local variables alongside `DIFF_BASE`, `DEFAULT_BRANCH`, etc. It never flows into `CompositionInputs`; composition makes no decision based on it. The flag's sole consumer is the preview warning prefix in Step 4.
+
+### 2c. `docs/solutions/` auto-detection
+
+If `docs/solutions/` exists at the repo root:
+
+```bash
+git log "$DIFF_BASE..HEAD" --name-only --pretty=format: -- docs/solutions/ | sort -u
+```
+
+For each entry returned:
+
+- Read the file's frontmatter and the first paragraph of `## Solution` (or first paragraph of body if no `## Solution`).
+- Prepare a one-line summary: `<frontmatter.problem or H1>` — link target relative to repo root.
+
+If at least one entry was returned, ask the user **per-entry** via AskUserQuestion:
+
+> "Found `docs/solutions/<path>`: '<summary>'. Include as 'What I learned'?"
+>
+> 1. **Include** — add to the splice set
+> 2. **Skip** — do not add
+> 3. **Include all remaining** — accept the rest without further prompts
+> 4. **Skip all remaining** — reject the rest
+
+`solutions = (<accepted entries>...)`. Empty tuple is normal.
+
+If `docs/solutions/` does not exist or returns no entries, set `solutions = ()` silently.
+
+### 2d. Preserved blocks from existing PR/MR description
+
+If an open PR/MR exists for the current branch:
+
+```bash
+# GitHub
+gh pr view --json url,state,body,isDraft
+
+# GitLab
+glab mr view -F json
+```
+
+If `state == OPEN`:
+
+- Extract `<!-- CURSOR_SUMMARY --> … <!-- /CURSOR_SUMMARY -->` block(s) — preserved verbatim.
+- Extract `## Demo` section (heading + content until next H2 or EOF).
+- Extract `## Screenshots` section (same shape).
+
+`preserved_blocks = ((kind="bugbot", raw_markdown=<text>), (kind="demo", raw_markdown=<text>), (kind="screenshots", raw_markdown=<text>))` — only kinds present.
+
+Step 5d re-fetches the body immediately before write and re-extracts these blocks at apply time — see Step 5d for the rationale. The Step 2d extract is what the preview displays; Step 5d's extract is what actually ships.
+
+If `MODE=full` and no open PR/MR, set `preserved_blocks = ()`.
+
+### 2e. Evidence (user-supplied URLs only)
+
+If the diff suggests user-observable behavior — UI files changed, e.g. files matching `*.tsx`, `*.jsx`, `*.vue`, `*.svelte`, `*.css`, `templates/`, `views/`, etc. — ask:
+
+> "This change appears user-visible. Include evidence?"
+>
+> 1. **Use existing evidence** — paste URL(s) or markdown embed → splice as `## Demo`
+> 2. **Skip** — no evidence section
+
+If "Use existing evidence", prompt for the markdown to splice. Accept whatever the user pastes verbatim (URL validation is out of scope — preview catches obvious issues).
+
+`evidence = ((kind="markdown", raw=<text>),)` or `()`.
+
+If no user-observable files changed, skip this prompt — `evidence = ()`.
+````
+
+#### Success Criteria
+
+##### Automated:
+- [ ] `grep 'mcp__claude_ai_Linear__get_issue' commands/ba/propose.md` — MCP tool referenced
+- [ ] `grep 'CompositionInputError' commands/ba/propose.md` — error types defined
+- [ ] `grep 'CURSOR_SUMMARY' commands/ba/propose.md` — BugBot sentinel mentioned
+- [ ] `grep '## Demo\|## Screenshots' commands/ba/propose.md` — preserved-block kinds enumerated
+- [ ] `grep 'docs/solutions/' commands/ba/propose.md` — solutions integration present
+- [ ] `grep 'origin/HEAD\|DEFAULT_BRANCH' commands/ba/propose.md` — default-branch detection present
+- [ ] `grep -c 'AskUserQuestion' commands/ba/propose.md` — interactive prompts increased (>= 8)
+
+##### Manual:
+- [ ] Linear-failure vs Linear-absence distinction is explicit; `mcp_unavailable` flag is set on failure.
+- [ ] `docs/solutions/` scan is per-entry confirmable; "include all"/"skip all" shortcuts present.
+- [ ] Preserved-block extraction is re-run at apply time in Step 5d (not compared by hash) so the published body always reflects the freshest remote read.
+- [ ] Evidence prompt only triggers on heuristic UI-file detection; otherwise silent.
+- [ ] Empty-diff distinguishes "branch fully contained in base" from "diff unreadable" with separate messages.
+
+> **Phase gate:** Automated verification must pass. Pause for manual verification before proceeding to Phase 3.
+
+---
+
+### Phase 3 — Composition spec (the seam)
+
+Document the `compose_body` contract inline in `commands/ba/propose.md` as Step 3. This is the section Claude reads to compute `title` and `body` from `CompositionInputs`. The brainstorm's locked design (interface, invariants, tier→section mapping, swappable internals) lifts in verbatim where it's contract-shaped.
+
+#### Changes Required
+
+**File**: `commands/ba/propose.md` (append Step 3)
+
+````markdown
+## Step 3: Compose body (the seam)
+
+This is the composition spec — Claude executes it to produce `title` and `body` from the inputs gathered in Step 2. It is pure: it reads from `CompositionInputs` only, performs no I/O, makes no MCP calls, runs no git commands. If you find yourself needing a fact that isn't in `CompositionInputs`, that's a gather-side bug — go back to Step 2.
+
+### Contract
+
+**Inputs** (already materialized in Step 2):
+
+```
+CompositionInputs:
+  diff               # range, file stats, commit log
+  branch             # name, base ref, last merge SHA
+  issue_context      # opaque Mapping or None
+  solutions          # tuple of accepted entries, possibly empty
+  preserved_blocks   # tuple of (kind, raw_markdown), possibly empty
+  evidence           # tuple of (kind, raw), possibly empty
+```
+
+**Outputs**:
+
+```
+ComposedBody:
+  title              # effect-phrased, ≤72 chars, no trailing period
+  body               # final markdown — feeds both commit and PR/MR
+```
+
+(See brainstorm: `## Locked Design`, *Interface*.)
+
+### Invariants (every composition pass must satisfy these)
+
+- `body` never restates the diff verbatim. The diff is visible on the platform; the body explains what the diff cannot show.
+- `title` is effect-phrased. If the initial draft is mechanism-only (e.g., "add a mutex to guard X"), rewrite to effect form ("prevent X during simultaneous Y") and stash the original for the preview's "rewritten from" disclosure.
+- Preserved blocks appear exactly once, byte-identical to input. Splice positions chosen internally.
+- Section order follows Lynch's priority (descriptive title → impact → motivation → breaking changes → external refs → dependency justifications → cross-refs → bug summaries → testing instr → testing limits → what I learned → alternatives → searchable artifacts → screenshots → rants → tempted-to-explain).
+- Empty inputs (no Linear, no solutions, no preserved blocks, tiny diff) still produce a valid minimal body.
+- Stateless; deterministic given identical inputs.
+
+Errors collapse to `CompositionInputError` — raised only by Step 2 when the diff is unreadable or empty. Composition itself does not raise.
+
+### Internal pipeline (seam-hidden, swappable)
+
+The implementation below is the first cut. Future authors can swap to pure-Lynch, pure-CE, or a continuous-score scheme without changing the call site. None of these names ("tier", "section selector", "splicer") appear in the orchestrator.
+
+#### 3.1 Classify size tier
+
+Read `diff.file_stats` and `diff.commit_log`. Compute totals:
+
+- `lines_changed = sum(additions + deletions across all files)`
+- `files_changed = count of files`
+- `is_perf = (lines_changed >= 30 AND any commit message in branch matches /perf|performance/) OR (diff includes a benchmark or measurement file — paths matching *bench*, *benchmark*, *measure*, *perf-test*, or files with `.bench.` infix)`
+- `is_typo = files_changed == 1 AND lines_changed <= 4 AND the change is pure string/comment/whitespace — no operators, no conditionals, no call expressions, no type annotations`
+
+Tier table (first match wins):
+
+| Tier | Heuristic |
+|---|---|
+| typo | `is_typo` |
+| perf | `is_perf` |
+| small | `lines_changed <= 30 AND files_changed <= 3` |
+| medium | `lines_changed <= 200 AND files_changed <= 10` |
+| large | otherwise |
+
+#### 3.2 Select default Lynch sections per tier
+
+Reference numbers are Lynch's menu (see `docs/research/2026-05-17-shipping-skill-source-material-research.md` *Source 4*).
+
+| Tier | Default sections |
+|---|---|
+| typo | #1 |
+| small | #1, #2, conditionally #3 if non-obvious motivation |
+| medium | #1, #2, #3, #7 (cross-refs), conditionally #9, #14, #11 |
+| large | #1, #2, #3, #4 (if breaking), #6 (if dep changes), #7, #8, #9, #10, #11, #12, #14 |
+| perf | #1, #2, #3, #14 (before/after table) |
+
+#### 3.3 Filter sections by content availability
+
+Drop any default section whose source is missing:
+
+- No `issue_context` → drop "Motivation from issue" sub-flavor of #3; derive motivation from `diff.commit_log` instead.
+- No `solutions` entries → drop #11.
+- No detected breaking change in diff (no API removal, no schema change) → drop #4.
+- No lockfile / dependency-manifest changes → drop #6.
+- No `evidence` AND no `preserved_blocks` of kind `demo`/`screenshots` → drop #14.
+
+#### 3.4 Generate section bodies
+
+For each surviving section, generate copy from the relevant inputs:
+
+- **#1 Title** — see 3.5 below.
+- **#2 Impact** — one sentence: what was impossible/broken before, what's possible/fixed now.
+- **#3 Motivation** — pull from `issue_context.raw` if present (read whatever fields exist; common shapes: `title`, `description`, `priority`); else derive from `diff.commit_log` and changed file paths.
+- **#4 Breaking changes** — name the breaking surface (removed API, schema migration, etc.) under a `**BREAKING:**` line. Never use `!` in the title or `BREAKING CHANGE:` trailer without explicit user confirmation.
+- **#6 Dependency justifications** — list lockfile-detected adds; one-line rationale per addition.
+- **#7 Cross-refs** — `Fixes <issue_context.identifier>` if applicable; never prefix list items with `#` (auto-links `#1` as issue ref — use `org/repo#N` or full URL).
+- **#8 Bug summaries** — paragraph form, never just `Fixes #N`. Pull from `issue_context.raw.description` if available.
+- **#9 Testing instructions** — only when automated tests don't exist for the change.
+- **#10 Testing limitations** — disclose what wasn't tested.
+- **#11 What I learned** — for each `solutions` entry, render as a bullet linking to the file with the entry's summary.
+- **#12 Alternatives considered** — only when the diff isn't self-explanatory.
+- **#14 Screenshots / Demo** — splice `evidence` markdown verbatim; if `preserved_blocks` includes `demo`/`screenshots`, prefer those byte-identical.
+
+#### 3.5 Title rewriting
+
+Draft a title from `diff.commit_log[0]` or the user's free-text hint if provided.
+
+Check for mechanism-only phrasing — leading verbs like `add`, `move`, `extract`, `refactor`, `update`, `change`, `bump`, `wrap` followed by a noun phrase that names a code construct (`mutex`, `class`, `function`, `field`, etc.) without naming the user-observable effect.
+
+If mechanism-only, rewrite to effect form. Stash the original as `rewritten_from` for the preview's disclosure line. Worked example from Lynch — keep in mind when judging:
+
+| Bad (mechanism) | Good (effect) |
+|---|---|
+| Add a mutex to guard the database handle | Prevent database corruption during simultaneous sign-ups |
+
+Cap at 72 chars. Strip trailing period. Imperative mood. Lowercase after the conventional-commits prefix.
+
+**`fix:` vs `feat:` rule** (from CE / `pr-description-writing.md`): when both fit, default to `fix:` — adding code to remedy missing behavior is `fix:`. Reserve `feat:` for capabilities the user could not previously accomplish.
+
+#### 3.6 Splice preserved blocks
+
+After sections are rendered, splice preserved blocks at their canonical positions:
+
+- `## Demo` → after #2 / #3, before #11.
+- `## Screenshots` → after `## Demo`, or in `## Demo`'s slot if no `## Demo`.
+- `<!-- CURSOR_SUMMARY --> … <!-- /CURSOR_SUMMARY -->` → at the very end of the body, after all generated sections and after any rants/tempted-to-explain content.
+
+Byte-identical: the raw markdown carried in `preserved_blocks` is inserted as-is. Do not re-format, re-indent, or alter whitespace.
+
+#### 3.7 Final assembly
+
+Commit message and PR/MR body share the same rendered string: `title + "\n\n" + body`. No per-commit-vs-PR divergence is computed here. If the user wants a tighter commit body than the PR body on a given run, they edit the preview (Step 4) — Per the brainstorm's *2026-05-19 Addendum — `--diverge` dropped*, the YAGNI rejection of Design B's `overrides` applies here too.
+
+#### 3.8 Soft size cap warning
+
+After full composition, count body lines. If `body` exceeds 150 lines (Lynch's soft cap for large tier), record a `size_warning = True` flag for the preview. Do not auto-trim — the user decides.
+
+### Trade-offs documented at lock time
+
+The seam intentionally exposes no tier flag, section list, template selector, or ordering hint to the orchestrator. Section-choice debugging requires reading this spec. If observability becomes a real pain point, add a `ComposedBody.trace` field later. (See brainstorm: `## Locked Design`, *Trade-offs*.)
+````
+
+#### Success Criteria
+
+##### Automated:
+- [ ] `grep '## Step 3' commands/ba/propose.md` — composition section exists
+- [ ] `grep -c 'tier' commands/ba/propose.md` — tier logic documented (>= 5 occurrences)
+- [ ] `grep 'CompositionInputs\|ComposedBody' commands/ba/propose.md` — contract types named
+- [ ] `grep 'Lynch' commands/ba/propose.md` — Lynch attribution present
+- [ ] `grep 'effect-phrased\|effect, not mechanism\|mechanism' commands/ba/propose.md` — title rewriting rule documented
+- [ ] `grep 'mutex.*sign-ups\|database corruption' commands/ba/propose.md` — Lynch worked example carried over
+- [ ] `grep '72 char\|72-char\|≤72\|<=72' commands/ba/propose.md` — title cap documented
+- [ ] `grep '150 line\|150-line\|>= 150\|>150' commands/ba/propose.md` — soft cap documented
+
+##### Manual:
+- [ ] Composition spec is clearly a contract Claude executes, not Python to import — phrased as instruction.
+- [ ] Section-vocabulary choice is visibly seam-hidden — the orchestrator never names a tier or section.
+- [ ] Linear MCP shape is read defensively (`issue_context.raw.<field> if available`), absorbing schema drift.
+- [ ] Filter step lists exact "drop section if source missing" rules from the brainstorm.
+
+> **Phase gate:** Automated verification must pass. Pause for manual verification before proceeding to Phase 4.
+
+---
+
+### Phase 4 — Preview, apply, failure-mode handling
+
+Add Steps 4 and 5: the preview/confirm gate, then the apply mechanics — `git commit` with `-F`, file-level staging, `git push` with non-fast-forward handling, `gh pr create` / `glab mr create` with `--body-file` heredoc discipline, edit-vs-create branching when an open PR/MR exists, hook-failure recovery, post-push PR-create failure messaging. Plus the explicit Failure Modes appendix.
+
+#### Changes Required
+
+**File**: `commands/ba/propose.md` (append Steps 4, 5, and Failure Modes)
+
+````markdown
+## Step 4: Preview and confirm
+
+Print the preview block:
+
+```
+─────────────────────────────────────────
+Mode: <full | describe-only>  (Host: <github|gitlab|...>)
+Title: <title>
+       (rewritten from: <rewritten_from>)             [if applicable]
+Body lines: <N>                                       size warning if N > 150
+Lead: <first two sentences of body>
+─────────────────────────────────────────
+[full body printed below]
+─────────────────────────────────────────
+```
+
+Tier observability is deliberately omitted from the preview — exposing the seam-internal vocabulary would break the "tier never named at call site" invariant from Step 3. If tier debugging becomes a real pain point, add an optional `ComposedBody.trace` field per the brainstorm's *Locked Design > Trade-offs*.
+
+Pre-prefix the block with warnings if any:
+
+- `⚠ Linear MCP unavailable — using diff-derived motivation` (from Step 2b)
+- `⚠ Composed body is <N> lines; Lynch's soft cap is ~150` (from Step 3.8)
+
+Then ask via AskUserQuestion:
+
+> "Apply?"
+>
+> 1. **Apply** — proceed to Step 5
+> 2. **Edit body** — open the body in `$EDITOR` (fallback `nano`), re-preview after save
+> 3. **Regenerate with hint** — prompt for a one-line hint, re-run Step 3 with the hint, re-preview
+> 4. **Exit** — abort without changes
+
+Loop until the user picks Apply or Exit.
+
+## Step 5: Apply
+
+Compose the per-mode action plan:
+
+| Mode / state | Actions |
+|---|---|
+| `full` (default) | 5a (stage) → 5b (commit) → 5c (push) → 5d (create or edit PR/MR — auto-detected) |
+| `full` + `skip_push=True` (nothing to push + open PR; user said "update description only") | 5d only (edits existing PR/MR) |
+| `describe-only` | print body to stdout; exit |
+
+### 5a. Stage explicit paths
+
+Identify the changed files from Step 2a's `--numstat` output. Stage all of them in a single commit using explicit paths only — no `git add -A`, no `git add .`:
+
+```bash
+git add path/to/file1 path/to/file2 path/to/file3
+```
+
+The command always produces one commit per run. Users who want multiple commits run `/ba:propose` twice on separately-staged subsets — the user already controls the grouping by deciding what to stage before the run. A heuristic split-by-subdirectory was considered and rejected as YAGNI: same lens as the brainstorm's *2026-05-19 Addendum — `--diverge` dropped*.
+
+### 5b. Commit
+
+Write the commit message to a temp file and pass via `-F`:
+
+```bash
+COMMIT_MSG_FILE=$(mktemp "${TMPDIR:-/tmp}/ba-propose-commit.XXXXXX")
+cat > "$COMMIT_MSG_FILE" <<'__BA_PROPOSE_COMMIT_END__'
+<title>
+
+<commit body — same content as PR/MR body>
+__BA_PROPOSE_COMMIT_END__
+
+git commit -F "$COMMIT_MSG_FILE"
+```
+
+The quoted sentinel `'__BA_PROPOSE_COMMIT_END__'` blocks `$VAR`, backticks, and literal `EOF` expansion.
+
+**Hook failure recovery.** If `git commit` returns non-zero:
+
+- Print the hook output verbatim.
+- Leave the working tree exactly as the hook left it.
+- Exit with message: "Hook failed — fix the reported issue and re-run `/ba:propose`. Composition outputs are deterministic; re-running re-derives them. Never re-run with `--no-verify` unless you've audited the hook and have an explicit reason."
+- Do NOT pass `--no-verify`. Never.
+
+### 5c. Push
+
+```bash
+git push -u origin HEAD
+```
+
+If push fails with non-fast-forward (rejected for `non-fast-forward` or `protected`):
+
+```bash
+git fetch origin "$BRANCH_NAME"
+git rev-list --left-right --count "origin/$BRANCH_NAME...HEAD"
+```
+
+Ask the user:
+
+> "Upstream `origin/<branch>` has commits not in your local branch. Force-pushing would discard them."
+>
+> 1. **Force-with-lease** — `git push --force-with-lease origin HEAD` (safe re-write; aborts if upstream changed since last fetch)
+> 2. **Abort** — leave the push undone; investigate manually
+
+Never `git push --force` without lease. Never silent.
+
+### 5d. Create or edit PR/MR
+
+If `HOST=unknown`:
+
+- Skip this step.
+- Print: "Host `<URL>` not supported by `ba:propose`. Composed body:" followed by the body.
+- Print: "Paste into your platform's UI manually. Commits were pushed successfully."
+- Exit zero (commit + push succeeded).
+
+Otherwise, check for existing open PR/MR:
+
+```bash
+# GitHub
+EXISTING_PR_URL=$(gh pr view --json url,state -q 'select(.state=="OPEN") | .url' 2>/dev/null)
+
+# GitLab
+EXISTING_MR_URL=$(glab mr view -F json 2>/dev/null | jq -r 'select(.state=="opened") | .web_url')
+```
+
+**Fetch-before-write** (when editing — close the BugBot-edit race window without a hash compare):
+
+```bash
+# Re-fetch body immediately before publish; re-extract preserved blocks from the now-current remote body
+CURRENT_BODY=$(gh pr view --json body -q .body)
+# (re-run the Step 2d extract on $CURRENT_BODY → fresh preserved_blocks tuple)
+```
+
+If the re-extracted preserved blocks differ from what Step 2d captured (the preview showed earlier), splice the *current* extract into the body being written. The preview may have shown a stale block; the published body always uses the freshest remote read. This costs one extra `gh pr view` call and ~5 lines of plan; in exchange we drop the hash capture, the three-way recovery menu, and one full re-loop through Steps 2d/3/4.
+
+The earlier-considered sha256 staleness check + interactive re-fetch/apply-anyway/abort menu was simplified out per the *2026-05-19 plan review* (same YAGNI lens as `--diverge`): preserved blocks are byte-identical by construction, so re-extracting from the latest remote read is sufficient — no comparison logic needed.
+
+**Write body to temp file** (always — no `--body "$(cat ...)"`, no stdin, no pipes):
+
+```bash
+BODY_FILE=$(mktemp "${TMPDIR:-/tmp}/ba-propose-body.XXXXXX")
+cat > "$BODY_FILE" <<'__BA_PROPOSE_BODY_END__'
+<full PR/MR body — same content as commit message>
+__BA_PROPOSE_BODY_END__
+```
+
+**Dispatch:**
+
+```bash
+# GitHub — create
+gh pr create \
+  --title "<title>" \
+  --body-file "$BODY_FILE" \
+  --base "$DEFAULT_BRANCH"
+
+# GitHub — edit existing
+gh pr edit "$EXISTING_PR_URL" \
+  --title "<title>" \
+  --body-file "$BODY_FILE"
+
+# GitLab — create
+glab mr create \
+  --title "<title>" \
+  --description-file "$BODY_FILE" \
+  --target-branch "$DEFAULT_BRANCH"
+
+# GitLab — edit existing
+glab mr update "$EXISTING_MR_URL" \
+  --title "<title>" \
+  --description-file "$BODY_FILE"
+```
+
+**Post-push PR-create failure.** If push succeeded in 5c but the `gh pr create` / `glab mr create` call fails:
+
+- Surface the platform's exact error message.
+- Print: "Push succeeded; PR/MR creation failed. Re-run `/ba:propose` after fixing the platform issue — commits are already pushed, so staging/commit/push are no-ops, and Step 5d will create the PR."
+- Exit non-zero. Do not retry automatically. Do not rewind the push.
+
+### 5e. Output
+
+On success, print:
+
+```
+✓ <title>
+  <PR or MR URL>
+```
+
+## Failure Modes
+
+| Failure | Where it surfaces | Recovery |
+|---|---|---|
+| Invalid branch state (detached HEAD, default branch with or without work) | Step 1 | Interactive routing per Step 1's four-way decision table — offer create-branch or refuse. |
+| `HOST=unknown` | Step 0a | Skip 5d; commit + push only; print body for manual paste. |
+| Empty diff (base moved) | Step 2a | `CompositionInputError` with rebase-or-close message. |
+| Linear MCP failure with ID present | Step 2b | Warn at preview; fall back to diff-derived motivation. |
+| Preserved-block race window | Step 5d | Re-fetch + re-extract immediately before publish; published body uses the freshest remote read. No interactive recovery needed. |
+| Body > 150 lines | Step 4 | Warn at preview; user decides. |
+| Hook failure on commit | Step 5b | Surface output, exit, never `--no-verify`. |
+| Non-fast-forward push | Step 5c | Offer `--force-with-lease` or abort. |
+| PR-create after-push fails | Step 5d | Surface error; instruct user to re-run `/ba:propose` (commits already pushed, so 5a-5c are no-ops, 5d retries the create). |
+
+## Important Guidelines
+
+- Composition is a pure contract — it consumes the value objects in `CompositionInputs` and reaches out to nothing. Add I/O? Add it to Step 2.
+- Never `git add -A` / `git add .`. Explicit paths only.
+- Never `--no-verify` unless the user has explicitly asked, with an audited reason.
+- Never silent force-push. `--force-with-lease` only, with explicit confirmation.
+- `--body-file` always points at a temp file written by a quoted-sentinel heredoc. Never `--body "$(cat ...)"`, never stdin, never pipes.
+- Preserved blocks (`<!-- CURSOR_SUMMARY -->`, `## Demo`, `## Screenshots`) are byte-identical in and out.
+- Linear is optional. Failure ≠ absence — warn at preview when MCP failed.
+- `docs/solutions/` absence is normal. Defensive empty-tuple.
+- The diff is visible on the platform; the body explains what the diff cannot show.
+- Title = effect, not mechanism. Rewrite if drafted as mechanism, disclose the rewrite in preview.
+- `fix:` over `feat:` when ambiguous.
+````
+
+#### Success Criteria
+
+##### Automated:
+- [ ] `grep '__BA_PROPOSE_BODY_END__\|__BA_PROPOSE_COMMIT_END__' commands/ba/propose.md` — quoted-sentinel heredoc markers present
+- [ ] `grep -c 'mktemp' commands/ba/propose.md` — temp-file pattern used (>= 2)
+- [ ] `grep 'force-with-lease' commands/ba/propose.md` — force-push policy present, no `--force` alone
+- [ ] `grep -E 'gh pr create|gh pr edit|glab mr create|glab mr update' commands/ba/propose.md` — all four host actions present
+- [ ] `grep '## Failure Modes' commands/ba/propose.md` — failure mode appendix present
+- [ ] `grep 'Hook failed' commands/ba/propose.md` — hook-failure recovery present
+- [ ] `grep -c 'AskUserQuestion' commands/ba/propose.md` — interactive prompts (final >= 12)
+- [ ] `commands/ba/propose.md` line count between 400 and 800 — in line with comparable commands
+
+##### Manual:
+- [ ] Preview block includes title, optional "rewritten from", line count, lead sentence, and warnings.
+- [ ] Edit-vs-create dispatch is conditional on `EXISTING_PR_URL` / `EXISTING_MR_URL`.
+- [ ] Step 5d re-fetches the PR body via `gh pr view --json body` (or `glab mr view`) and re-extracts preserved blocks from the freshest remote read immediately before publishing — no hash compare, no interactive menu.
+- [ ] Step 5a stages all changed files in a single commit using explicit paths only; no heuristic-based multi-commit grouping prompt.
+- [ ] `HOST=unknown` path completes commit + push but never invokes platform-specific create — falls through gracefully.
+- [ ] Post-push PR-create failure does not retry, does not rewind the push, and gives a clear `--describe-only` recovery path.
+
+> **Phase gate:** Automated verification must pass. Pause for manual verification before proceeding to Phase 5.
+
+---
+
+### Phase 5 — Docs updates and version bump
+
+Update `CLAUDE.md`, `README.md`, and `.claude-plugin/plugin.json` so the new command, new category, and new convention are documented in all three places per the established convention (`CLAUDE.md:74` — "Update README.md whenever commands, agents, or artifact paths are added or changed").
+
+#### Changes Required
+
+**File**: `CLAUDE.md`
+
+Insert a new `### Git workflow Commands` subsection between Knowledge (line 28) and `## Agents` (line 30). Verbatim block to insert at line 29:
+
+```markdown
+
+### Git Workflow Commands (ship code — commit, push, open PR/MR)
+
+- `/ba:propose [--describe-only] [--issue <ID>]` — Commit, push, and open PR/MR with a composed title and body
+```
+
+Append a new convention bullet at the end of `## Conventions` (currently `CLAUDE.md:74`):
+
+```markdown
+- Git workflow commands (`ba:propose`) commit, push, and open PR/MR — they never modify source files outside the staged diff
+```
+
+**File**: `README.md`
+
+Insert a new `### /ba:propose [args]` block at line 172 (immediately before `### Severity ladder and confidence anchors (/ba:review)`):
+
+```markdown
+### /ba:propose [--describe-only] [--issue <ID>]
+
+Commit, push, and open a PR/MR with a composed title and body.
+
+- Pure-function body composition: orchestrator gathers inputs (diff, branch, Linear, docs/solutions, preserved blocks, evidence) → composition reads value objects and returns title + body
+- Host-detected dispatch: GitHub `gh`, GitLab `glab`, graceful fallback for unknown hosts (compose + push only)
+- Body composition selects from Michael Lynch's 16-section menu, sized to the diff — the size-tier vocabulary is hidden behind the composition seam (no flag, no preview surface)
+- Linear MCP optional with diff-derived fallback; clear preview warning when MCP is unavailable
+- `docs/solutions/` auto-detection on current-branch-touched entries; per-entry confirm to splice as "What I learned"
+- Cursor BugBot block and existing `## Demo` / `## Screenshots` preserved byte-identical
+- Commit message and PR/MR body share the same composed markdown — no separate render path
+- `--body-file` discipline (temp file + quoted-sentinel heredoc); no `git add -A`/`.`; no `--no-verify`; `--force-with-lease` only
+- Preview-then-confirm always — apply / edit / regenerate-with-hint / exit
+```
+
+**File**: `.claude-plugin/plugin.json`
+
+Bump version, extend description, add keyword.
+
+Before:
+
+```json
+{
+  "name": "dev-workflow",
+  "version": "0.17.0",
+  "description": "Research, brainstorm, plan, slice, execute, review, and compound commands with triage, convention compliance, and knowledge compounding",
+  ...
+  "keywords": [
+    "research", "brainstorm", "planning", "slice", "execute",
+    "workflow", "conventions", "review", "compound", "knowledge"
+  ]
+}
+```
+
+After:
+
+```json
+{
+  "name": "dev-workflow",
+  "version": "0.18.0",
+  "description": "Research, brainstorm, plan, slice, execute, review, compound, and propose commands with triage, convention compliance, and knowledge compounding",
+  ...
+  "keywords": [
+    "research", "brainstorm", "planning", "slice", "execute",
+    "workflow", "conventions", "review", "compound", "knowledge", "propose"
+  ]
+}
+```
+
+#### Success Criteria
+
+##### Automated:
+- [ ] `grep 'Git Workflow Commands' CLAUDE.md` — new category present
+- [ ] `grep '/ba:propose' CLAUDE.md` — command listed in CLAUDE.md
+- [ ] `grep 'Git workflow commands.*never modify source files' CLAUDE.md` — convention bullet present
+- [ ] `grep '/ba:propose' README.md` — command listed in README
+- [ ] `grep -c 'force-with-lease\|--body-file' README.md` — discipline bullets visible to users (>= 1)
+- [ ] `grep '"version": "0.18.0"' .claude-plugin/plugin.json` — version bumped
+- [ ] `grep '"propose"' .claude-plugin/plugin.json` — keyword added
+- [ ] `grep '"description":.*propose' .claude-plugin/plugin.json` — description updated
+
+##### Manual:
+- [ ] CLAUDE.md `### Git Workflow Commands` section reads as a peer of the other category subsections, not a footnote.
+- [ ] README `### /ba:propose` block matches the style of `/ba:slice` and `/ba:compound` (one-line description + bullet list).
+- [ ] `plugin.json` version bump matches semver convention for a new command (`0.X.0` minor bump).
+- [ ] No accidental edits to `marketplace.json` (out of scope).
+- [ ] No accidental edits to `commands/ba/execute.md`'s "Create MR/PR" delegation — that menu may eventually point at `/ba:propose` but is out of scope here.
+
+> **Phase gate:** Automated verification must pass. Manual verification completes the plan.
+
+---
+
+## System-Wide Impact
+
+### Interaction Graph
+
+When `/ba:propose` runs in `full` mode:
+
+```
+user             →   /ba:propose
+orchestrator     →   git remote / git status / git rev-parse / git fetch / git diff / git log
+orchestrator     →   mcp__claude_ai_Linear__get_issue (optional)
+orchestrator     →   docs/solutions/ scan (file read)
+orchestrator     →   gh pr view --json url,state,body  /  glab mr view -F json (when existing PR)
+composition      ←   (returns title + body — no callouts)
+orchestrator     →   AskUserQuestion (preview confirm)
+orchestrator     →   git add <files>
+orchestrator     →   git commit -F <tempfile>  (triggers pre-commit, commit-msg hooks)
+orchestrator     →   git push -u origin HEAD  (triggers pre-push hook)
+orchestrator     →   gh pr create --body-file <tempfile>  /  glab mr create --description-file <tempfile>
+                     OR gh pr edit / glab mr update (when existing PR)
+```
+
+External callbacks affected: any pre-commit / commit-msg / pre-push hook the repo has installed. The command does not bypass them.
+
+### Error & Failure Propagation
+
+- Gather-side errors (Step 2) raise `CompositionInputError` — never reach composition.
+- Composition errors are not allowed by contract — it produces a valid body or it's a code bug to fix.
+- Apply-side errors (Step 5) surface verbatim to the user with explicit recovery instructions:
+  - Hook failure: working tree untouched, exit non-zero, user fixes and re-runs.
+  - Push rejection: explicit `--force-with-lease` confirmation, no silent override.
+  - PR-create failure after push success: separate `--describe-only` recovery flow documented.
+- MCP failure with ID present: warning bubbles to preview, no exception thrown.
+- `docs/solutions/` directory missing: defensive empty-tuple, silent.
+
+### State Lifecycle Risks
+
+The command makes mutations in this order: commit (local) → push (remote) → create/edit PR (remote). A failure between push and create-PR leaves a pushed branch with no PR — recovery is simply re-running `/ba:propose`: commits are already pushed, so 5a-5c are no-ops and 5d creates the PR. The fetch-before-write at the start of Step 5d ensures the freshest preserved blocks are spliced into the published body.
+
+No per-repo state file is written by `ba:propose`. Earlier drafts cached a `--diverge` answer in `.git/dev-workflow/propose-config`; that flag was dropped post-capture (see brainstorm: *2026-05-19 Addendum — `--diverge` dropped*) and the cache went with it.
+
+### API Surface Parity
+
+GitHub and GitLab adapters expose equivalent capability:
+
+| Operation | GitHub | GitLab |
+|---|---|---|
+| View open PR/MR | `gh pr view --json url,state,body,isDraft` | `glab mr view -F json` |
+| Create | `gh pr create --title <T> --body-file <F> --base <B>` | `glab mr create --title <T> --description-file <F> --target-branch <B>` |
+| Edit | `gh pr edit <URL> --title <T> --body-file <F>` | `glab mr update <URL> --title <T> --description-file <F>` |
+
+GHES uses `gh` with `GH_HOST` env. Self-hosted GitLab uses `glab` with its own config. Unknown hosts skip the create/edit step entirely.
+
+### Integration Test Scenarios
+
+Five cross-layer scenarios that unit-level greps would not catch:
+
+1. **GitHub feature branch, no existing PR, full workflow, no Linear, no solutions, no evidence.** Confirms minimal-input happy path produces a short body (composition-internal "small" tier; not named at call site) and `gh pr create --body-file` succeeds.
+2. **GitLab feature branch, existing open MR, BugBot block present, no new commits to push.** Step 0b detects the open MR + nothing-to-push and asks "update description only?" — on Yes, Step 5 skips push and Step 5d calls `glab mr update` (not `glab mr create`); BugBot block round-trips byte-identical.
+3. **Substantive change (>200 lines, >10 files) with multiple `docs/solutions/` hits, per-entry confirm.** Confirms per-entry AskUserQuestion, "include all"/"skip all" shortcuts, and that the composed body splices accepted entries as "What I learned" while dropping rejected ones.
+4. **Linear MCP unavailable (server stopped), branch name `bru/TO-123-fix-x`.** Confirms preview shows the "Linear MCP unavailable" warning, body uses diff-derived motivation, command does not error.
+5. **Unknown host (`git@bitbucket.org:org/repo.git`), feature branch, full workflow.** Confirms commit + push succeed, the create-PR step is skipped with the "paste manually" message, body is printed in full, exit code is zero.
+
+## Risk Analysis & Mitigation
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| `--body-file` discipline regresses (someone adds `--body "$(cat ...)"` in a future edit) | High | Automated grep in Success Criteria; explicit Important Guidelines bullet; the Failure Modes table singles it out. |
+| Composition seam leaks (orchestrator starts reading composition internals) | Medium | Locked design documented in Step 3; reviewers can flag drift. |
+| Preserved-block byte-identity breaks (a future composition tweak alters whitespace) | High | Step 3.6 explicitly says "raw markdown is inserted as-is — do not re-format"; success criterion includes BugBot round-trip behavior. |
+| MCP schema drift breaks Linear motivation | Low | `issue_context.raw: Mapping[str, Any]` is opaque — composition reads "whatever fields exist if available." |
+| `gh`/`glab` not installed | Medium | Detection failure in Step 0a leads to `HOST=unknown` path; no hard dependency assertion. |
+| Hook bypass via accident | High | Explicit "never `--no-verify`" rule; Failure Modes recovery is fix-and-retry, never bypass. |
+| Force-push catastrophic | High | Only `--force-with-lease`, only after explicit AskUserQuestion confirmation. |
+| Title rewrite changes intent silently | Medium | Always disclose `rewritten from: <original>` in preview when a rewrite occurred. |
+| Body too long without warning | Low | Soft cap warning at preview; user decides. |
+
+## Testing Strategy
+
+This repo has no test harness — verification is structural greps + manual scenario walk-throughs (see `docs/plans/2026-03-14-feat-add-ba-execute-command-plan.md` for the canonical precedent). The `Success Criteria` per phase above codifies both.
+
+**Manual scenario coverage** corresponds 1:1 to the five Integration Test Scenarios above. Each can be exercised by running `/ba:propose` against a real branch with the relevant repo configuration. The author should run all five before tagging v0.18.0.
+
+**Convention-checker re-run** (already done at plan capture; success criteria covers the conventions the plan introduces).
+
+## Documentation Plan
+
+- `commands/ba/propose.md` — new, ~500–700 LoC, the command itself.
+- `CLAUDE.md` — new category subsection + new convention bullet.
+- `README.md` — new `### /ba:propose` block.
+- `.claude-plugin/plugin.json` — version + description + keywords.
+
+Not in this plan:
+- `marketplace.json` bump (separate cadence).
+- `docs/solutions/` seeding (handled organically by `/ba:compound` after first usage).
+- Roadmap `✅` (added post-release if at all).
+
+## Dependencies & Risks
+
+**External CLIs required at runtime:**
+- `gh` — GitHub CLI. Installation: `brew install gh` / `apt install gh`. Authentication: `gh auth login`.
+- `glab` — GitLab CLI. Installation: `brew install glab`. Authentication: `glab auth login`.
+
+**Optional MCP server:**
+- Linear MCP (`mcp__claude_ai_Linear__*`). Absence is silently tolerated; presence is auto-detected.
+
+**Risks tracked above** in *Risk Analysis & Mitigation*.
+
+## Sources & References
+
+### Origin
+
+- Brainstorm: `docs/brainstorms/2026-05-19-ba-propose-shipping-skill-brainstorm.md`. Key decisions carried forward:
+  - Command name `ba:propose` and new "Git workflow" category (see brainstorm: `## Key Decisions`).
+  - Hybrid Locked Design — A's pure-function composition + C's opaque value-object inputs (see brainstorm: `## Locked Design`).
+  - Acceptance criteria items 1–11 (see brainstorm: `## Acceptance Criteria`).
+  - Scope boundaries (see brainstorm: `## Scope Boundaries`).
+  - Carry-over from CE: mode dispatch, four-way branch tree, file-level commit splitting, `--body-file` discipline, preview-apply summary, `fix:` vs `feat:`, `#`-list-prefix gotcha (see brainstorm: `## Key Decisions`).
+  - Carry-over from `mr` skill: Linear MCP optional, BugBot preservation, Lynch effect-vs-mechanism worked example.
+  - Drops from `mr`: fixed 3-heading template, hardcoded `time-off` scope, 50-char title cap, GitLab-only orientation.
+
+### Internal References
+
+- Existing command file structures: `commands/ba/execute.md`, `commands/ba/review.md`, `commands/ba/compound.md`, `commands/ba/plan.md`.
+- Existing `gh`/`glab` usage precedent (read-only): `commands/ba/review.md:76-86`.
+- Existing `--body-file` precedent (issue creation): `commands/ba/plan.md:507`.
+- Existing `docs/solutions/` defensive pattern: `commands/ba/compound.md:55-61`.
+- Existing test-strategy precedent: `docs/plans/2026-03-14-feat-add-ba-execute-command-plan.md:459-482`.
+- Standing synthesis-lock rule: `docs/brainstorms/2026-05-02-ousterhout-principles-roadmap-brainstorm.md` *### Concrete rules*.
+
+### External References
+
+- Michael Lynch, *How to Write Useful Commit Messages* — `https://refactoringenglish.com/chapters/commit-messages/` (extracted in `docs/research/2026-05-17-shipping-skill-source-material-research.md` Source 4).
+- EveryInc `ce-commit-push-pr` skill — extracted in `docs/research/2026-05-17-shipping-skill-source-material-research.md` Source 1.
+- Local `mr` skill — `~/.claude/skills/mr/SKILL.md` (Bruno's machine; reference only).
+- Cursor BugBot sentinel format — extracted in `docs/research/2026-05-17-shipping-skill-source-material-research.md` Source 5.
+
+## Convention Compliance
+
+- [x] Filename matches `YYYY-MM-DD-<type>-<name>-plan.md` — `2026-05-19-feat-add-ba-propose-command-plan.md`
+- [x] YAML frontmatter present with `title`, `type`, `status`, `date`, `origin`, `detail_level`, `iteration_count`, `tags`
+- [x] Plan does not write source code — only specifies markdown command file + doc updates
+- [x] Command prefix `ba:` honored
+- [x] `What We're NOT Doing` section present
+- [x] Per-phase Success Criteria separated into Automated and Manual
+- [x] Phase gates pause for manual verification before next phase
+- [x] Exact file paths and concrete code blocks used (no placeholder pseudo-paths)
+- [x] CLAUDE.md `## Conventions` update planned (Phase 5)
+- [x] README.md update planned (Phase 5)
+- [x] `version` bump in `.claude-plugin/plugin.json` planned (Phase 5)
+- [x] Composition-spec Python signatures retained as design contract — template-sanctioned per the brainstorm's design-it-twice template (see brainstorm: `## Convention Compliance`, *Informational*)
+- [x] New "Git workflow" command category added to CLAUDE.md per brainstorm's Convention Compliance directive
+- [x] Origin brainstorm reference present in frontmatter and Sources
+- [x] All built-in reviewers / protected-artifact rules unaffected by this plan


### PR DESCRIPTION
## Summary

Brainstorm + implementation plan for a new `ba:propose` command — a Git-workflow command that commits, pushes, and opens a PR/MR with a composed title and body. **Planning artifact only** — no command/code changes yet. The plan is the input to `/ba:execute`, which will land `commands/ba/propose.md`, the CLAUDE.md / README updates, and bump `plugin.json` to 0.18.0.

Plan: [`docs/plans/2026-05-19-feat-add-ba-propose-command-plan.md`](../blob/worktree-ba-propose-plan/docs/plans/2026-05-19-feat-add-ba-propose-command-plan.md)
Brainstorm: [`docs/brainstorms/2026-05-19-ba-propose-shipping-skill-brainstorm.md`](../blob/worktree-ba-propose-plan/docs/brainstorms/2026-05-19-ba-propose-shipping-skill-brainstorm.md)
HTML render (1063-line plan, easier to review): [`docs/plans/2026-05-19-feat-add-ba-propose-command-plan.html`](../blob/worktree-ba-propose-plan/docs/plans/2026-05-19-feat-add-ba-propose-command-plan.html) — clone + open locally for sticky TOC, scrollspy, phase-gate callouts, and syntax-highlighted embedded markdown.

## What the plan proposes

- New `/ba:propose [--describe-only] [--issue <ID>]` command in a new **Git workflow** category alongside Research / Planning / Execution / Quality / Knowledge.
- **Pure-function composition seam**: orchestrator gathers inputs (diff, branch, Linear MCP, `docs/solutions/`, preserved blocks, evidence); composition reads value objects and returns title + body. No tier/section vocabulary leaks to the call site.
- **Host-detected dispatch**: GitHub `gh`, GitLab `glab`, graceful fallback for unknown hosts (compose + push only).
- **`--body-file` heredoc discipline** — first command in the repo to issue `gh pr create` / `glab mr create`; quoted-sentinel tempfile, never `--body "\$(cat …)"`, never stdin, never pipes.
- **Preview-then-confirm always** — apply / edit / regenerate-with-hint / exit.
- Cursor BugBot and existing `## Demo` / `## Screenshots` preserved byte-identical; re-extract at apply time closes the BugBot-edit race window without a hash compare.
- Five phases, each with Automated + Manual success criteria and phase gates.

## Test plan

- [ ] Read the plan top-to-bottom (HTML render recommended for the 1063-line scroll)
- [ ] Confirm the four-way branch-routing tree (detached HEAD / default+work / default+no-work / feature) covers all CE cases
- [ ] Verify Linear-failure vs Linear-absence distinction (Step 2b) and that `mcp_unavailable` stays orchestrator-side
- [ ] Sanity-check the BugBot re-fetch-before-write design in Step 5d vs. the rejected hash-compare alternative
- [ ] Confirm the \"What We're NOT Doing\" list matches the brainstorm's scope boundaries (no `--diverge`, no auto-`/ba:review`, no `marketplace.json` bump)
- [ ] Spot-check the Phase 5 doc deltas: new CLAUDE.md \"Git Workflow Commands\" subsection + convention bullet, new README `/ba:propose` block, `plugin.json` 0.17.0 → 0.18.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)