### PR TITLE
feat(ba-propose): commit, push, and open PR/MR with a composed body

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-workflow",
   "version": "0.18.0",
-  "description": "Research, brainstorm, plan, slice, execute, review, and compound commands with triage, convention compliance, and knowledge compounding",
+  "description": "Research, brainstorm, plan, slice, execute, review, compound, and propose commands with triage, convention compliance, and knowledge compounding",
   "author": {
     "name": "Bruno Azevedo"
   },
@@ -16,6 +16,7 @@
     "conventions",
     "review",
     "compound",
-    "knowledge"
+    "knowledge",
+    "propose"
   ]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,10 @@ Claude Code plugin providing brainstorm and plan commands with triage, conventio
 
 - `/ba:compound [context]` — Document solved problems to `docs/solutions/` for future learnings
 
+### Git Workflow Commands (ship code — commit, push, open PR/MR)
+
+- `/ba:propose [--describe-only] [--issue <ID>]` — Commit, push, and open PR/MR with a composed title and body
+
 ## Agents
 
 - `repo-researcher` — Codebase structure, patterns, and CLAUDE.md conventions
@@ -72,3 +76,4 @@ Claude Code plugin providing brainstorm and plan commands with triage, conventio
 - All built-in reviewers always appear as options in `/ba:review` — external reviewers are shown alongside them with overlap notes, never hidden or replaced
 - `/ba:review` dispatches reviewer subagents with a protected-artifacts guard naming `docs/brainstorms/`, `docs/plans/`, `docs/solutions/`, `docs/research/`, and `docs/reviews/` — reviewers must not suggest deleting, relocating, or otherwise removing files under these roots (content review is unaffected)
 - Update README.md whenever commands, agents, or artifact paths are added or changed
+- Git workflow commands (`ba:propose`) commit, push, and open PR/MR — they never modify source files outside the staged diff

--- a/README.md
+++ b/README.md
@@ -170,6 +170,20 @@ Documents solved problems into `docs/solutions/` so the `learnings-researcher` a
 - **Fix application** — apply all fixes, Critical + High + Med-conf-100 (Critical + High at displayed confidence plus Medium only when confidence == 100), or one-by-one with Accept/Skip per finding; runs targeted tests after applying
 - **Optional persistence** — pass `--persist` to write per-reviewer outputs and a `summary.md` to a dated `docs/reviews/YYYY-MM-DD-HHMMSS-<scope-ref>/` directory. The command does **not** modify your repo's `.gitignore`; if you want persisted runs kept out of version control, ignore `docs/reviews/` yourself (e.g. via `.git/info/exclude`, a global gitignore, or your repo's own `.gitignore`). Default behavior (no flag) is unchanged
 
+### /ba:propose [--describe-only] [--issue <ID>]
+
+Commit, push, and open a PR/MR with a composed title and body.
+
+- Pure-function body composition: orchestrator gathers inputs (diff, branch, Linear, docs/solutions, preserved blocks, evidence) → composition reads value objects and returns title + body
+- Host-detected dispatch: GitHub `gh`, GitLab `glab`, graceful fallback for unknown hosts (compose + push only)
+- Body composition selects from Michael Lynch's 16-section menu, sized to the diff — the size-tier vocabulary is hidden behind the composition seam (no flag, no preview surface)
+- Linear MCP optional with diff-derived fallback; clear preview warning when MCP is unavailable
+- `docs/solutions/` auto-detection on current-branch-touched entries; per-entry confirm to splice as "What I learned"
+- Cursor BugBot block and existing `## Demo` / `## Screenshots` preserved byte-identical
+- Commit message and PR/MR body share the same composed markdown — no separate render path
+- `--body-file` discipline (temp file + quoted-sentinel heredoc); no `git add -A`/`.`; no `--no-verify`; `--force-with-lease` only
+- Preview-then-confirm always — apply / edit / regenerate-with-hint / exit
+
 ### Severity ladder and confidence anchors (`/ba:review`)
 
 All `/ba:review` reviewers — built-in and external — emit findings under a four-level ladder + a positive bucket:

--- a/commands/ba/propose.md
+++ b/commands/ba/propose.md
@@ -372,3 +372,217 @@ After full composition, count `body` lines. Emit `ComposedBody.size_warning = (l
 ### Trade-offs documented at lock time
 
 The seam intentionally exposes no tier flag, section list, template selector, or ordering hint to the orchestrator. Section-choice debugging requires reading this spec. If observability becomes a real pain point, add a `ComposedBody.trace` field later. (See brainstorm: `## Locked Design`, *Trade-offs*.)
+
+## Step 4: Preview and confirm
+
+Print the preview block:
+
+```
+─────────────────────────────────────────
+Action: <commit_push_create | commit_push_edit | edit_only | describe_only>  (Host: <github|gitlab|...>)
+Title: <result.title>
+       (rewritten from: <result.rewritten_from>)      [only if result.rewritten_from is not None]
+Body lines: <N>                                       (size warning prefix if result.size_warning)
+Lead: <first two sentences of result.body>
+─────────────────────────────────────────
+[full result.body printed below]
+─────────────────────────────────────────
+```
+
+Tier observability is deliberately omitted from the preview — exposing the seam-internal vocabulary would break the "tier never named at call site" invariant from Step 3. If tier debugging becomes a real pain point, add an optional `ComposedBody.trace` field per the brainstorm's *Locked Design > Trade-offs*.
+
+Pre-prefix the block with warnings if any:
+
+- `⚠ Linear MCP unavailable — using diff-derived motivation` (from `mcp_unavailable` orchestrator flag set in Step 2b)
+- `⚠ Composed body is <N> lines (long for typical PR descriptions — consider trimming)` (when `result.size_warning` is True; phrasing avoids surfacing the "Lynch's soft cap" source vocabulary)
+
+Then ask via AskUserQuestion:
+
+> "Apply?"
+>
+> 1. **Apply** — proceed to Step 5
+> 2. **Edit body** — open the body in `$EDITOR` (fallback `nano`), re-preview after save
+> 3. **Regenerate with hint** — prompt for a one-line hint, re-run Step 3 with the hint, re-preview
+> 4. **Exit** — abort without changes
+
+Loop until the user picks Apply or Exit.
+
+## Step 5: Apply
+
+Step 5 dispatches on the single `ACTION` value resolved in Step 0b. The `HOST=unknown` case short-circuits inside 5d regardless of `ACTION`.
+
+| `ACTION` | Actions |
+|---|---|
+| `commit_push_create` | 5a (stage) → 5b (commit) → 5c (push) → 5d (create PR/MR) |
+| `commit_push_edit` | 5a (stage) → 5b (commit) → 5c (push) → 5d (edit existing PR/MR) |
+| `edit_only` | 5d only (edit existing PR/MR description; no commit, no push) |
+| `describe_only` | Print body to stdout; exit zero. |
+
+`HOST=unknown` overlay: when `HOST=unknown` and `ACTION` is any of the three apply variants, 5a-5c run as normal (commit and push still succeed against the remote), but 5d short-circuits to "paste manually" mode — see 5d's host-unknown handling. The matrix is closed: every (`ACTION`, `HOST`) pair has defined behavior.
+
+### 5a. Stage explicit paths
+
+Identify the changed files from Step 2a's `--numstat` output. Stage all of them in a single commit using explicit paths only — no `git add -A`, no `git add .`:
+
+```bash
+git add path/to/file1 path/to/file2 path/to/file3
+```
+
+The command always produces one commit per run. Users who want multiple commits run `/ba:propose` twice on separately-staged subsets — the user already controls the grouping by deciding what to stage before the run. A heuristic split-by-subdirectory was considered and rejected as YAGNI: same lens as the brainstorm's *2026-05-19 Addendum — `--diverge` dropped*.
+
+### 5b. Commit
+
+Write the commit message to a temp file and pass via `-F`:
+
+```bash
+COMMIT_MSG_FILE=$(mktemp "${TMPDIR:-/tmp}/ba-propose-commit.XXXXXX")
+cat > "$COMMIT_MSG_FILE" <<'__BA_PROPOSE_COMMIT_END__'
+<title>
+
+<commit body — same content as PR/MR body>
+__BA_PROPOSE_COMMIT_END__
+
+git commit -F "$COMMIT_MSG_FILE"
+```
+
+The quoted sentinel `'__BA_PROPOSE_COMMIT_END__'` blocks `$VAR`, backticks, and literal `EOF` expansion.
+
+**Hook failure recovery.** If `git commit` returns non-zero:
+
+- Print the hook output verbatim.
+- Leave the working tree exactly as the hook left it.
+- Exit with message: "Hook failed — fix the reported issue and re-run `/ba:propose`. Composition outputs are deterministic; re-running re-derives them. Never re-run with `--no-verify` unless you've audited the hook and have an explicit reason."
+- Do NOT pass `--no-verify`. Never.
+
+### 5c. Push
+
+```bash
+git push -u origin HEAD
+```
+
+If push fails with non-fast-forward (rejected for `non-fast-forward` or `protected`):
+
+```bash
+git fetch origin "$BRANCH_NAME"
+git rev-list --left-right --count "origin/$BRANCH_NAME...HEAD"
+```
+
+Ask the user:
+
+> "Upstream `origin/<branch>` has commits not in your local branch. Force-pushing would discard them."
+>
+> 1. **Force-with-lease** — `git push --force-with-lease origin HEAD` (safe re-write; aborts if upstream changed since last fetch)
+> 2. **Abort** — leave the push undone; investigate manually
+
+Never `git push --force` without lease. Never silent.
+
+### 5d. Create or edit PR/MR
+
+If `HOST=unknown`:
+
+- Skip this step.
+- Print: "Host `<URL>` not supported by `ba:propose`. Composed body:" followed by the body.
+- Print: "Paste into your platform's UI manually. Commits were pushed successfully."
+- Exit zero (commit + push succeeded).
+
+Otherwise, check for existing open PR/MR:
+
+```bash
+# GitHub
+EXISTING_PR_URL=$(gh pr view --json url,state -q 'select(.state=="OPEN") | .url' 2>/dev/null)
+
+# GitLab
+EXISTING_MR_URL=$(glab mr view -F json 2>/dev/null | jq -r 'select(.state=="opened") | .web_url')
+```
+
+**Fetch-before-write** (when editing — last read wins):
+
+```bash
+# Re-fetch body immediately before publish; re-extract preserved blocks from the now-current remote body
+CURRENT_BODY=$(gh pr view --json body -q .body)
+# (re-run the Step 2d extract on $CURRENT_BODY → fresh preserved_blocks tuple)
+```
+
+**Invariant**: Preserved blocks are byte-identical by construction (Step 3.4 inserts the raw markdown as-is). The *last* read of the remote body wins; an explicit hash comparison adds no information. So if the re-extracted preserved blocks differ from what Step 2d captured, the fresh extract is authoritative.
+
+**Splice via re-composition, not manual edit.** To incorporate the fresh preserved blocks without leaking Step 3.4's splice-position rules into the orchestrator, rebuild `CompositionInputs` with the fresh `preserved_blocks` tuple and call `compose_body` a second time. By the determinism invariant (Step 3 contract), `title` and the non-preserved sections of `body` re-derive identically because all other inputs are unchanged; the only change between the preview's composed body and the published body is the (refreshed) preserved-block content at their canonical positions. The orchestrator never names a splice position. Cost: one extra composition pass (no I/O, deterministic) and one extra `gh pr view` round-trip; in exchange the seam stays narrow and "preview ≈ publish" holds modulo the freshest preserved blocks.
+
+Surface a one-line notice in 5d's output when the published body's preserved blocks differ from those shown at preview: `ℹ Preserved blocks updated between preview and publish — published body uses the latest remote read.` This keeps the user informed without recreating the rejected interactive recovery menu.
+
+**Write body to temp file** (always — no `--body "$(cat ...)"`, no stdin, no pipes):
+
+```bash
+BODY_FILE=$(mktemp "${TMPDIR:-/tmp}/ba-propose-body.XXXXXX")
+cat > "$BODY_FILE" <<'__BA_PROPOSE_BODY_END__'
+<full PR/MR body — same content as commit message>
+__BA_PROPOSE_BODY_END__
+```
+
+**Dispatch:**
+
+```bash
+# GitHub — create
+gh pr create \
+  --title "<title>" \
+  --body-file "$BODY_FILE" \
+  --base "$DEFAULT_BRANCH"
+
+# GitHub — edit existing
+gh pr edit "$EXISTING_PR_URL" \
+  --title "<title>" \
+  --body-file "$BODY_FILE"
+
+# GitLab — create
+glab mr create \
+  --title "<title>" \
+  --description-file "$BODY_FILE" \
+  --target-branch "$DEFAULT_BRANCH"
+
+# GitLab — edit existing
+glab mr update "$EXISTING_MR_URL" \
+  --title "<title>" \
+  --description-file "$BODY_FILE"
+```
+
+**Post-push PR-create failure.** If push succeeded in 5c but the `gh pr create` / `glab mr create` call fails:
+
+- Surface the platform's exact error message.
+- Print: "Push succeeded; PR/MR creation failed. Re-run `/ba:propose` after fixing the platform issue — commits are already pushed, so staging/commit/push are no-ops, and Step 5d will create the PR."
+- Exit non-zero. Do not retry automatically. Do not rewind the push.
+
+### 5e. Output
+
+On success, print:
+
+```
+✓ <title>
+  <PR or MR URL>
+```
+
+## Failure Modes
+
+| Failure | Where it surfaces | Recovery |
+|---|---|---|
+| Invalid branch state (detached HEAD, default branch with or without work) | Step 1 | Interactive routing per Step 1's four-way decision table — offer create-branch or refuse. |
+| `HOST=unknown` | Step 0a | Skip 5d; commit + push only; print body for manual paste. |
+| Empty diff (base moved) | Step 2a | `CompositionInputError` with rebase-or-close message. |
+| Linear MCP failure with ID present | Step 2b | Warn at preview; fall back to diff-derived motivation. |
+| Preserved-block race window | Step 5d | Re-fetch + re-extract immediately before publish; published body uses the freshest remote read. No interactive recovery needed. |
+| Body > 150 lines | Step 4 | Warn at preview; user decides. |
+| Hook failure on commit | Step 5b | Surface output, exit, never `--no-verify`. |
+| Non-fast-forward push | Step 5c | Offer `--force-with-lease` or abort. |
+| PR-create after-push fails | Step 5d | Surface error; instruct user to re-run `/ba:propose` (commits already pushed, so 5a-5c are no-ops, 5d retries the create). |
+
+## Important Guidelines
+
+- Composition is a pure contract — it consumes the value objects in `CompositionInputs` and reaches out to nothing. Add I/O? Add it to Step 2.
+- Never `git add -A` / `git add .`. Explicit paths only.
+- Never `--no-verify` unless the user has explicitly asked, with an audited reason.
+- Never silent force-push. `--force-with-lease` only, with explicit confirmation.
+- `--body-file` always points at a temp file written by a quoted-sentinel heredoc. Never `--body "$(cat ...)"`, never stdin, never pipes.
+- Preserved blocks (`<!-- CURSOR_SUMMARY -->`, `## Demo`, `## Screenshots`) are byte-identical in and out.
+- Linear is optional. Failure ≠ absence — warn at preview when MCP failed.
+- `docs/solutions/` absence is normal. Defensive empty-tuple.
+- The diff is visible on the platform; the body explains what the diff cannot show.
+- Title = effect, not mechanism. Rewrite if drafted as mechanism, disclose the rewrite in preview.
+- `fix:` over `feat:` when ambiguous.

--- a/commands/ba/propose.md
+++ b/commands/ba/propose.md
@@ -106,4 +106,140 @@ DEFAULT_BRANCH=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null |
 
 If still empty, ask the user.
 
-## Step 2: … (continued in Phase 2)
+## Step 2: Gather inputs
+
+Each sub-step materializes one field of `CompositionInputs`. None of this happens inside composition.
+
+### 2a. Diff and branch metadata
+
+```bash
+git fetch --no-tags origin "$DEFAULT_BRANCH"
+DIFF_BASE=$(git merge-base HEAD "origin/$DEFAULT_BRANCH")
+git diff --stat "$DIFF_BASE..HEAD"
+git diff --numstat "$DIFF_BASE..HEAD"
+git log --pretty=oneline "$DIFF_BASE..HEAD"
+git rev-parse --abbrev-ref HEAD
+```
+
+Capture into the orchestrator's local state:
+
+- `diff.range = "$DIFF_BASE..HEAD"`
+- `diff.file_stats = <output of --numstat>`
+- `diff.commit_log = <output of --pretty=oneline>`
+- `branch.name = <current branch>`
+- `branch.base_ref = "origin/$DEFAULT_BRANCH"`
+- `branch.last_merge_sha = "$DIFF_BASE"`
+
+If `git diff --stat "$DIFF_BASE..HEAD"` is empty AND there are commits in the log, raise the empty-diff error:
+
+> **CompositionInputError: branch is fully contained in base.**
+> Your commits exist but the diff vs `<DEFAULT_BRANCH>` is empty. Likely causes: someone landed equivalent changes in `<DEFAULT_BRANCH>` and your branch is now redundant, or the base was force-pushed past your branch tip. Rebase, or close the branch.
+
+If `git diff --stat` is non-empty but unreadable (returns non-zero with no diff), raise:
+
+> **CompositionInputError: diff unreadable.**
+> `git diff $DIFF_BASE..HEAD` returned non-zero. Check the repository state.
+
+### 2b. Linear issue context (optional)
+
+Determine the issue ID:
+
+1. If `--issue <ID>` was passed, use it.
+2. Else, regex-extract from branch name: `[A-Z]{2,5}-[0-9]+` (e.g., `bru/TO-1234-fix-x` → `TO-1234`).
+3. Else, no issue ID — skip MCP entirely, `issue_context = None`.
+
+If an ID is present, attempt the MCP call:
+
+```
+mcp__claude_ai_Linear__get_issue(id: <ID>)
+```
+
+- **Success** → normalize the MCP payload into composition-owned vocabulary before passing it across the seam:
+
+  ```
+  issue_context = IssueContext(
+    ref         = <mcp_response>.identifier,        # e.g., "TO-1234"
+    summary     = <mcp_response>.title,             # short headline
+    body_text   = <mcp_response>.description,       # long-form description, possibly empty
+    priority    = <mcp_response>.priority,          # optional, opaque to composition
+    raw         = <full mcp_response, Mapping[str, Any]>,
+  )
+  ```
+
+  The normalizer is Step 2b's job, not composition's. If Linear renames `description` → `body` or `identifier` → `key` in a future MCP schema, that change lands here in Step 2b and never reaches Step 3. Composition reads `issue_context.ref`, `.summary`, `.body_text` — not Linear's field names. The `.raw` mapping is retained as an escape hatch but composition should not read it for production sections; reach for `.raw` only when prototyping a new section, then promote the field into the normalizer.
+- **Failure** (MCP not installed, server down, auth expired, ID not found) → `issue_context = None`, AND record `mcp_unavailable = True` so the preview can surface a warning: "Linear MCP unavailable — using diff-derived motivation."
+
+The orchestrator never raises on MCP failure. Linear is optional.
+
+`mcp_unavailable` is **orchestrator-side state only** — it lives in the run-local variables alongside `DIFF_BASE`, `DEFAULT_BRANCH`, etc. It never flows into `CompositionInputs`; composition makes no decision based on it. The flag's sole consumer is the preview warning prefix in Step 4.
+
+### 2c. `docs/solutions/` auto-detection
+
+If `docs/solutions/` exists at the repo root:
+
+```bash
+git log "$DIFF_BASE..HEAD" --name-only --pretty=format: -- docs/solutions/ | sort -u
+```
+
+For each entry returned:
+
+- Read the file's frontmatter and the first paragraph of `## Solution` (or first paragraph of body if no `## Solution`).
+- Prepare a one-line summary: `<frontmatter.problem or H1>` — link target relative to repo root.
+
+If at least one entry was returned, ask the user **once**, presenting the full list:
+
+> "Found N `docs/solutions/` entries touched on this branch:
+> 1. `<path-1>` — <summary-1>
+> 2. `<path-2>` — <summary-2>
+> ...
+>
+> Include as 'What I learned'?"
+>
+> 1. **Include all** — splice every detected entry
+> 2. **Skip all** — splice none
+> 3. **Choose** — drop into a per-entry yes/no loop (only when the user wants surgical control)
+
+Default for the typical case (1–3 entries) is "Include all" — that's what the loop is gathering. The per-entry **Choose** path opens an AskUserQuestion sequence with a single yes/no per remaining entry; no Include-all / Skip-all shortcuts at that level (the user already picked "Choose" because they want individual control).
+
+`solutions = (<accepted entries>...)`. Empty tuple is normal.
+
+If `docs/solutions/` does not exist or returns no entries, set `solutions = ()` silently. The directory does not exist in the repo today — this code path is dormant until `/ba:compound` creates the first entry.
+
+### 2d. Preserved blocks from existing PR/MR description
+
+If an open PR/MR exists for the current branch:
+
+```bash
+# GitHub
+gh pr view --json url,state,body,isDraft
+
+# GitLab
+glab mr view -F json
+```
+
+If `state == OPEN`:
+
+- Extract `<!-- CURSOR_SUMMARY --> … <!-- /CURSOR_SUMMARY -->` block(s) — preserved verbatim.
+- Extract `## Demo` section (heading + content until next H2 or EOF).
+- Extract `## Screenshots` section (same shape).
+
+`preserved_blocks = ((kind="bugbot", raw_markdown=<text>), (kind="demo", raw_markdown=<text>), (kind="screenshots", raw_markdown=<text>))` — only kinds present.
+
+Step 5d re-fetches the body immediately before write and re-extracts these blocks at apply time — see Step 5d for the rationale. The Step 2d extract is what the preview displays; Step 5d's extract is what actually ships.
+
+If `ACTION` is one of `commit_push_create` / `describe_only` and no open PR/MR exists for the branch, set `preserved_blocks = ()`. The `commit_push_edit` and `edit_only` cases imply an open PR/MR by Step 0b's resolution, so this branch isn't reached for those actions.
+
+### 2e. Evidence (user-supplied URLs only)
+
+If the diff suggests user-observable behavior — UI files changed, e.g. files matching `*.tsx`, `*.jsx`, `*.vue`, `*.svelte`, `*.css`, `templates/`, `views/`, etc. — ask:
+
+> "This change appears user-visible. Include evidence?"
+>
+> 1. **Use existing evidence** — paste URL(s) or markdown embed → splice as `## Demo`
+> 2. **Skip** — no evidence section
+
+If "Use existing evidence", prompt for the markdown to splice. Accept whatever the user pastes verbatim (URL validation is out of scope — preview catches obvious issues).
+
+`evidence = ((kind="markdown", raw=<text>),)` or `()`.
+
+If no user-observable files changed, skip this prompt — `evidence = ()`.

--- a/commands/ba/propose.md
+++ b/commands/ba/propose.md
@@ -58,27 +58,35 @@ Compute a single `ACTION` value that drives the rest of the orchestration. Every
 | `commit_push_edit` | No `--describe-only` AND open PR/MR exists AND there are commits to push | 5a stage → 5b commit → 5c push → 5d edit. |
 | `edit_only` | No `--describe-only` AND open PR/MR exists AND nothing to push | Skip 5a-5c; 5d edits the existing PR/MR description. |
 
-Resolution sequence:
+Resolution sequence — also caches `OPEN_PR_URL` for reuse by Steps 2d and 5d so the open-PR probe runs exactly once per command invocation:
 
 ```bash
 ACTION=commit_push_create
+OPEN_PR_URL=""
 if [[ "$ARGS" == *--describe-only* ]]; then
   ACTION=describe_only
 else
-  # Probe upstream and open-PR state once
+  # Probe upstream once.
   HAS_COMMITS_TO_PUSH=$([[ -n "$(git rev-list @{upstream}..HEAD 2>/dev/null)" ]] && echo yes || echo no)
-  OPEN_PR_EXISTS=$(... gh pr view / glab mr view — see Step 2d's probe ...)
-  if [[ "$OPEN_PR_EXISTS" == yes && "$HAS_COMMITS_TO_PUSH" == no ]]; then
+
+  # Probe open-PR/MR state once; cache the URL (empty string when none).
+  if [[ "$HOST" == "github" || "$HOST" == "ghes" ]]; then
+    OPEN_PR_URL=$(gh pr view --json url,state -q 'select(.state=="OPEN") | .url' 2>/dev/null)
+  elif [[ "$HOST" == "gitlab" || "$HOST" == "gitlab-self" ]]; then
+    OPEN_PR_URL=$(glab mr view -F json 2>/dev/null | jq -r 'select(.state=="opened") | .web_url')
+  fi
+
+  if [[ -n "$OPEN_PR_URL" && "$HAS_COMMITS_TO_PUSH" == no ]]; then
     # Confirm the edit-only intent — refusing this exits early
     ask "Nothing to push. Update the PR description only?" yes/no
     [[ answer == yes ]] && ACTION=edit_only || exit 0
-  elif [[ "$OPEN_PR_EXISTS" == yes ]]; then
+  elif [[ -n "$OPEN_PR_URL" ]]; then
     ACTION=commit_push_edit
   fi
 fi
 ```
 
-After Step 0b, every downstream step reads `ACTION` and nothing else for mode dispatch. `MODE` and `skip_push` are not separate variables — they were intermediate concepts in an earlier draft, collapsed at plan-review time into `ACTION` so cross-step state is named once. The Step 5 action plan table (below) dispatches on `ACTION` directly.
+After Step 0b, every downstream step reads `ACTION` and `OPEN_PR_URL` and nothing else for mode dispatch / PR-targeting. `MODE` and `skip_push` are not separate variables — they were intermediate concepts in an earlier draft, collapsed at plan-review time into `ACTION` so cross-step state is named once. The Step 5 action plan table (below) dispatches on `ACTION` directly; `OPEN_PR_URL` is the canonical PR identifier threaded through Steps 2d and 5d.
 
 ## Step 1: Branch routing
 
@@ -100,9 +108,13 @@ Detect branch state and route per CE's four-way decision tree (see `docs/researc
 
 ```bash
 DEFAULT_BRANCH=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's@^origin/@@')
-[[ -z "$DEFAULT_BRANCH" ]] && DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name 2>/dev/null)
+if [[ -z "$DEFAULT_BRANCH" && ( "$HOST" == "github" || "$HOST" == "ghes" ) ]]; then
+  DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name 2>/dev/null)
+fi
 [[ -z "$DEFAULT_BRANCH" ]] && DEFAULT_BRANCH=$(git remote show origin 2>/dev/null | awk '/HEAD branch/ {print $NF}')
 ```
+
+The `gh repo view` probe is guarded behind `HOST=github|ghes` so a non-GitHub remote (GitLab, Bitbucket, unknown) does not invoke the wrong CLI. `git symbolic-ref` is host-agnostic and tried first; `git remote show origin` is the host-agnostic fallback that carries the unknown-host case.
 
 If still empty, ask the user.
 
@@ -186,20 +198,26 @@ For each entry returned:
 - Read the file's frontmatter and the first paragraph of `## Solution` (or first paragraph of body if no `## Solution`).
 - Prepare a one-line summary: `<frontmatter.problem or H1>` — link target relative to repo root.
 
-If at least one entry was returned, ask the user **once**, presenting the full list:
+If at least one entry was returned, ask the user **once** via `AskUserQuestion`. Print the numbered list of detected entries (with summaries) as the question text so the user can see what's being included before choosing:
 
-> "Found N `docs/solutions/` entries touched on this branch:
-> 1. `<path-1>` — <summary-1>
-> 2. `<path-2>` — <summary-2>
-> ...
->
-> Include as 'What I learned'?"
->
-> 1. **Include all** — splice every detected entry
-> 2. **Skip all** — splice none
-> 3. **Choose** — drop into a per-entry yes/no loop (only when the user wants surgical control)
+```
+AskUserQuestion(
+  question: "Found N docs/solutions/ entries touched on this branch:\n
+            1. <path-1> — <summary-1>\n
+            2. <path-2> — <summary-2>\n
+            ...\n
+            \nInclude as 'What I learned'?",
+  header: "Solutions",
+  multiSelect: false,
+  options: [
+    { label: "Include all",  description: "Splice every detected entry" },
+    { label: "Skip all",     description: "Splice none" },
+    { label: "Choose",       description: "Drop into a per-entry yes/no loop (surgical control)" },
+  ],
+)
+```
 
-Default for the typical case (1–3 entries) is "Include all" — that's what the loop is gathering. The per-entry **Choose** path opens an AskUserQuestion sequence with a single yes/no per remaining entry; no Include-all / Skip-all shortcuts at that level (the user already picked "Choose" because they want individual control).
+Default for the typical case (1–3 entries) is "Include all" — that's what the loop is gathering. The per-entry **Choose** path opens a follow-up `AskUserQuestion` sequence with a single yes/no per remaining entry; no Include-all / Skip-all shortcuts at that level (the user already picked "Choose" because they want individual control).
 
 `solutions = (<accepted entries>...)`. Empty tuple is normal.
 
@@ -396,7 +414,9 @@ Pre-prefix the block with warnings if any:
 - `⚠ Linear MCP unavailable — using diff-derived motivation` (from `mcp_unavailable` orchestrator flag set in Step 2b)
 - `⚠ Composed body is <N> lines (long for typical PR descriptions — consider trimming)` (when `result.size_warning` is True; phrasing avoids surfacing the "Lynch's soft cap" source vocabulary)
 
-Then ask via AskUserQuestion:
+**`describe_only` short-circuit.** When `ACTION=describe_only`, the preview block IS the output — print it and exit zero. Do NOT ask `AskUserQuestion`; a dry-run flag must not require the user to navigate a confirmation menu before delivering its result. (Peer commands `/ba:review --local` and `/ba:slice` follow the same rule.)
+
+For every other `ACTION`, ask via `AskUserQuestion`:
 
 > "Apply?"
 >
@@ -485,15 +505,20 @@ If `HOST=unknown`:
 - Print: "Paste into your platform's UI manually. Commits were pushed successfully."
 - Exit zero (commit + push succeeded).
 
-Otherwise, check for existing open PR/MR:
+Otherwise, reuse the cached `OPEN_PR_URL` from Step 0b — the open-PR/MR probe runs once per invocation, not three times:
 
 ```bash
-# GitHub
-EXISTING_PR_URL=$(gh pr view --json url,state -q 'select(.state=="OPEN") | .url' 2>/dev/null)
-
-# GitLab
-EXISTING_MR_URL=$(glab mr view -F json 2>/dev/null | jq -r 'select(.state=="opened") | .web_url')
+# Reuse the cached URL from Step 0b. Empty string means "no open PR/MR" → take the create path; non-empty → take the edit path.
+if [[ -n "$OPEN_PR_URL" ]]; then
+  # edit existing PR/MR — $OPEN_PR_URL is the canonical handle
+  :
+else
+  # create a new PR/MR
+  :
+fi
 ```
+
+If `OPEN_PR_URL` was populated in Step 0b but the PR has since been closed (race window between probe and apply — see *Failure Modes*), the platform's `edit` call will fail with a not-found error; surface the error per the *Post-push PR-create failure* recovery below.
 
 **Fetch-before-write** (when editing — last read wins):
 
@@ -528,7 +553,7 @@ gh pr create \
   --base "$DEFAULT_BRANCH"
 
 # GitHub — edit existing
-gh pr edit "$EXISTING_PR_URL" \
+gh pr edit "$OPEN_PR_URL" \
   --title "<title>" \
   --body-file "$BODY_FILE"
 
@@ -539,7 +564,7 @@ glab mr create \
   --target-branch "$DEFAULT_BRANCH"
 
 # GitLab — edit existing
-glab mr update "$EXISTING_MR_URL" \
+glab mr update "$OPEN_PR_URL" \
   --title "<title>" \
   --description-file "$BODY_FILE"
 ```
@@ -572,6 +597,7 @@ On success, print:
 | Hook failure on commit | Step 5b | Surface output, exit, never `--no-verify`. |
 | Non-fast-forward push | Step 5c | Offer `--force-with-lease` or abort. |
 | PR-create after-push fails | Step 5d | Surface error; instruct user to re-run `/ba:propose` (commits already pushed, so 5a-5c are no-ops, 5d retries the create). |
+| PR closed between Step 0b probe and Step 5d apply | Step 5d | The `gh pr edit` / `glab mr update` call against the cached `OPEN_PR_URL` will fail with a not-found error. Surface the platform error verbatim; instruct the user to re-run `/ba:propose` (the next probe will see no open PR and take the create path). |
 
 ## Important Guidelines
 

--- a/commands/ba/propose.md
+++ b/commands/ba/propose.md
@@ -243,3 +243,132 @@ If "Use existing evidence", prompt for the markdown to splice. Accept whatever t
 `evidence = ((kind="markdown", raw=<text>),)` or `()`.
 
 If no user-observable files changed, skip this prompt — `evidence = ()`.
+
+## Step 3: Compose body (the seam)
+
+This is the composition spec — Claude executes it to produce `title` and `body` from the inputs gathered in Step 2. It is pure: it reads from `CompositionInputs` only, performs no I/O, makes no MCP calls, runs no git commands. If you find yourself needing a fact that isn't in `CompositionInputs`, that's a gather-side bug — go back to Step 2.
+
+### Contract
+
+**Inputs** (already materialized in Step 2):
+
+```
+CompositionInputs:
+  diff               # range, file stats, commit log
+  branch             # name, base ref, last merge SHA
+  issue_context      # opaque Mapping or None
+  solutions          # tuple of accepted entries, possibly empty
+  preserved_blocks   # tuple of (kind, raw_markdown), possibly empty
+  evidence           # tuple of (kind, raw), possibly empty
+```
+
+**Outputs**:
+
+```
+ComposedBody:
+  title              # effect-phrased, ≤72 chars, no trailing period
+  body               # final markdown — feeds both commit and PR/MR
+  rewritten_from     # str or None — original title when 3.3 rewrote a mechanism-only draft; None when no rewrite occurred
+  size_warning       # bool — True when body exceeds Lynch's ~150-line soft cap (3.6)
+```
+
+`rewritten_from` and `size_warning` are declared output fields so the orchestrator's preview (Step 4) reads them by name; composition never side-channels state to the orchestrator. The seam stays one-direction: inputs in, ComposedBody out.
+
+(See brainstorm: `## Locked Design`, *Interface*.)
+
+### Invariants (every composition pass must satisfy these)
+
+- `body` never restates the diff verbatim. The diff is visible on the platform; the body explains what the diff cannot show.
+- `title` is effect-phrased. If the initial draft is mechanism-only (e.g., "add a mutex to guard X"), rewrite to effect form ("prevent X during simultaneous Y") and stash the original for the preview's "rewritten from" disclosure.
+- Preserved blocks appear exactly once, byte-identical to input. Splice positions chosen internally.
+- Section order follows Lynch's priority (descriptive title → impact → motivation → breaking changes → external refs → dependency justifications → cross-refs → bug summaries → testing instr → testing limits → what I learned → alternatives → searchable artifacts → screenshots → rants → tempted-to-explain).
+- Empty inputs (no Linear, no solutions, no preserved blocks, tiny diff) still produce a valid minimal body.
+- Stateless; deterministic given identical inputs.
+
+Errors collapse to `CompositionInputError` — raised only by Step 2 when the diff is unreadable or empty. Composition itself does not raise.
+
+### Internal pipeline (seam-hidden, swappable)
+
+The implementation below is the first cut. Future authors can swap to pure-Lynch, pure-CE, or a continuous-score scheme without changing the call site. None of these names ("tier", "section selector", "splicer") appear in the orchestrator.
+
+#### 3.1 Classify size tier
+
+Read `diff.file_stats` and `diff.commit_log`. Compute totals:
+
+- `lines_changed = sum(additions + deletions across all files)`
+- `files_changed = count of files`
+- `is_perf = (lines_changed >= 30 AND any commit message in branch matches /perf|performance/) OR (diff includes a benchmark or measurement file — paths matching *bench*, *benchmark*, *measure*, *perf-test*, or files with `.bench.` infix)`
+- `is_typo = files_changed == 1 AND lines_changed <= 4 AND the change is pure string/comment/whitespace — no operators, no conditionals, no call expressions, no type annotations`
+
+Tier table (first match wins):
+
+| Tier | Heuristic |
+|---|---|
+| typo | `is_typo` |
+| perf | `is_perf` |
+| small | `lines_changed <= 30 AND files_changed <= 3` |
+| medium | `lines_changed <= 200 AND files_changed <= 10` |
+| large | otherwise |
+
+#### 3.2 Section registry (tier threshold + source requirement + body rule)
+
+One declarative table replaces the earlier three-step pipeline (tier→sections → filter-by-availability → per-section generator). Each row owns one section: the minimum tier at which it activates, the input that must be present for it to appear, and the rule for generating its body. To add a new section, add one row. To add a new tier, raise/lower thresholds in this column only. Reviewers maintaining the spec read one place to see what each section depends on.
+
+Reference numbers are Lynch's menu (see `docs/research/2026-05-17-shipping-skill-source-material-research.md` *Source 4*). "Activates at" uses the tier order `typo < small < medium < large`; `perf` is a tier-modifier (see 3.1 note below) that activates rows tagged with `perf` regardless of size threshold.
+
+| # | Section | Activates at | Required input (drop section if missing) | Body rule |
+|---|---|---|---|---|
+| 1 | Title | typo | — | See 3.3 (title rewriting). Always present. |
+| 2 | Impact | small | — | One sentence: what was impossible/broken before, what's possible/fixed now. Falls back to commit log when motivation is thin. |
+| 3 | Motivation | small (when non-obvious), medium+, perf | — | Lead with `issue_context.summary` and expand from `issue_context.body_text` when `issue_context` is present; else derive from `diff.commit_log` and changed file paths. Composition reads only composition-owned fields; the Linear-shape mapping lives in Step 2b. |
+| 4 | Breaking changes | large | Diff signals an API removal or schema change | Name the breaking surface (removed API, schema migration, etc.) under a `**BREAKING:**` line. Never use `!` in the title or `BREAKING CHANGE:` trailer without explicit user confirmation. |
+| 6 | Dependency justifications | large | Lockfile / dependency-manifest changes in diff | List lockfile-detected adds; one-line rationale per addition. |
+| 7 | Cross-refs | medium, large | `issue_context.ref` is present | `Fixes <issue_context.ref>` (normalized ref from Step 2b, e.g., `TO-1234`). Never prefix list items with `#` (auto-links `#1` — use `org/repo#N` or full URL). |
+| 8 | Bug summaries | large | `issue_context.body_text` is present | Paragraph form, never just `Fixes #N`. |
+| 9 | Testing instructions | medium (conditional), large | Automated tests don't exist for the change | Spell out the manual verification path. |
+| 10 | Testing limitations | large | — | Disclose what wasn't tested. |
+| 11 | What I learned | medium (conditional), large | `solutions` is non-empty | For each `solutions` entry, render as a bullet linking to the file with the entry's `.summary`. |
+| 12 | Alternatives considered | large | Diff isn't self-explanatory | Brief notes on rejected approaches. |
+| 14 | Screenshots / Demo | medium (conditional), large, perf | `evidence` is non-empty OR `preserved_blocks` contains `demo`/`screenshots` | Splice `evidence` markdown verbatim; when `preserved_blocks` contains `demo`/`screenshots`, prefer those byte-identical. For perf tier, render as a before/after table. |
+
+For each row whose tier threshold is satisfied by `tier` AND whose required input is present in `CompositionInputs`, generate the body per the rule. Rows whose threshold isn't met or whose input is missing emit nothing — no second-pass filter needed. Section ordering follows Lynch's priority (#1 → #2 → #3 → #4 → #6 → #7 → #8 → #9 → #10 → #11 → #12 → #14); preserved blocks splice into canonical positions (Step 3.4).
+
+> **Note on `perf` as a tier-modifier**: a perf-typed change can be small *or* large by line count. The table treats `perf` as a flag that activates row #3 and row #14 regardless of size threshold; size-derived threshold rules still apply to other rows. This avoids the "first-match-wins" gotcha where a tiny perf change would otherwise classify as `typo` and drop row #14's before/after table.
+
+#### 3.3 Title rewriting
+
+Draft a title from `diff.commit_log[0]` or the user's free-text hint if provided.
+
+Check for mechanism-only phrasing — leading verbs like `add`, `move`, `extract`, `refactor`, `update`, `change`, `bump`, `wrap` followed by a noun phrase that names a code construct (`mutex`, `class`, `function`, `field`, etc.) without naming the user-observable effect.
+
+If mechanism-only, rewrite to effect form. Emit the original on `ComposedBody.rewritten_from` (declared in the Outputs contract above); leave `ComposedBody.rewritten_from = None` when no rewrite was needed. Worked example from Lynch — keep in mind when judging:
+
+| Bad (mechanism) | Good (effect) |
+|---|---|
+| Add a mutex to guard the database handle | Prevent database corruption during simultaneous sign-ups |
+
+Cap at 72 chars. Strip trailing period. Imperative mood. Lowercase after the conventional-commits prefix.
+
+**`fix:` vs `feat:` rule** (from CE / `pr-description-writing.md`): when both fit, default to `fix:` — adding code to remedy missing behavior is `fix:`. Reserve `feat:` for capabilities the user could not previously accomplish.
+
+#### 3.4 Splice preserved blocks
+
+After sections are rendered, splice preserved blocks at their canonical positions:
+
+- `## Demo` → after #2 / #3, before #11.
+- `## Screenshots` → after `## Demo`, or in `## Demo`'s slot if no `## Demo`.
+- `<!-- CURSOR_SUMMARY --> … <!-- /CURSOR_SUMMARY -->` → at the very end of the body, after all generated sections and after any rants/tempted-to-explain content.
+
+Byte-identical: the raw markdown carried in `preserved_blocks` is inserted as-is. Do not re-format, re-indent, or alter whitespace.
+
+#### 3.5 Final assembly
+
+Commit message and PR/MR body share the same rendered string: `title + "\n\n" + body`. No per-commit-vs-PR divergence is computed here. If the user wants a tighter commit body than the PR body on a given run, they edit the preview (Step 4) — Per the brainstorm's *2026-05-19 Addendum — `--diverge` dropped*, the YAGNI rejection of Design B's `overrides` applies here too.
+
+#### 3.6 Soft size cap warning
+
+After full composition, count `body` lines. Emit `ComposedBody.size_warning = (line_count > 150)` (Lynch's soft cap for large tier). Do not auto-trim — the user decides. The preview at Step 4 reads `size_warning` by name; composition never side-channels state to the orchestrator.
+
+### Trade-offs documented at lock time
+
+The seam intentionally exposes no tier flag, section list, template selector, or ordering hint to the orchestrator. Section-choice debugging requires reading this spec. If observability becomes a real pain point, add a `ComposedBody.trace` field later. (See brainstorm: `## Locked Design`, *Trade-offs*.)

--- a/commands/ba/propose.md
+++ b/commands/ba/propose.md
@@ -1,0 +1,109 @@
+---
+name: ba:propose
+description: Commit, push, and open a PR/MR with a composed title and body — preview-then-confirm, host-detected dispatch for GitHub and GitLab.
+argument-hint: "[--describe-only] [--issue <ID>] [optional: free-text hint]"
+---
+
+# Propose Changes for Review
+
+Compose a commit and PR/MR body that helps the code reviewer first, teammates and future-bug-investigators next.
+
+## Arguments
+
+<propose_args> #$ARGUMENTS </propose_args>
+
+### Parse Arguments
+
+Strip recognized flags from the argument string; what remains is a free-text hint that the user wants reflected in motivation.
+
+Recognized flags:
+
+- `--describe-only` — Compose and print the body; do not commit, push, or create/edit a PR/MR. Useful as a dry run.
+- `--issue <ID>` — Explicitly bind a Linear issue ID. Overrides branch-name detection.
+
+Note: there is no explicit `--describe-update` flag. Step 0b resolves a single `ACTION` enum (one of `commit_push_create` / `commit_push_edit` / `edit_only` / `describe_only`) from the args and the branch state; Steps 5a-5d dispatch on `ACTION`. The "nothing to push + open PR" case resolves to `edit_only` via a single confirmation prompt in 0b. One arg flag, one `ACTION` enum, no cross-product of mode + skip flags.
+
+## Step 0: Pre-flight
+
+### 0a. Detect remote host
+
+```bash
+REMOTE_URL=$(git remote get-url origin 2>/dev/null || echo "")
+```
+
+Parse `REMOTE_URL` to classify:
+
+- Matches `github.com` → `HOST=github`, `CLI=gh`.
+- Matches `gitlab.com` → `HOST=gitlab`, `CLI=glab`.
+- Else → `HOST=unknown` (unless the user overrides via the env-var escape hatch below).
+- No remote at all → `HOST=unknown`.
+
+**Env-var escape hatch** for self-hosted users (GHES, self-hosted GitLab):
+
+- If `BA_PROPOSE_HOST=ghes` is set, treat as `HOST=ghes`, `CLI=gh`. Caller is responsible for `gh auth login` and `GH_HOST` if needed.
+- If `BA_PROPOSE_HOST=gitlab-self` is set, treat as `HOST=gitlab-self`, `CLI=glab`. Caller is responsible for `glab auth login`.
+
+This replaces an earlier ladder design (`gh api /meta` probe → `glab config get` probe → unknown). The probe ladder was rejected at plan-review time as YAGNI for v0.18.0 — the repo has no documented GHES / self-hosted GitLab users today, the probes have unspecified failure semantics (CLI-missing vs probe-error), and probe #2 had the side effect of mutating `GH_HOST` in the caller's environment. Re-add auto-detection in a future plan when a real user reports the escape hatch is insufficient.
+
+If `HOST=unknown`, announce: "Remote `<URL>` is not GitHub or GitLab. `ba:propose` will still commit and push, but cannot open the PR/MR — paste the composed body into your platform's web UI when prompted. (Self-hosted? Set `BA_PROPOSE_HOST=ghes` or `BA_PROPOSE_HOST=gitlab-self`.)"
+
+### 0b. Resolve ACTION
+
+Compute a single `ACTION` value that drives the rest of the orchestration. Every state the rest of the command cares about — describe vs apply, commit-push-then-PR vs PR-edit-only — collapses into one named enum so Step 5 dispatches on one dimension instead of a cross-product:
+
+| `ACTION` | Triggered when | Step 5 behavior |
+|---|---|---|
+| `describe_only` | `--describe-only` was passed | Compose, preview, print body, exit zero. No commit, no push, no PR/MR write. |
+| `commit_push_create` | No `--describe-only` AND no open PR/MR for branch | 5a stage → 5b commit → 5c push → 5d create. |
+| `commit_push_edit` | No `--describe-only` AND open PR/MR exists AND there are commits to push | 5a stage → 5b commit → 5c push → 5d edit. |
+| `edit_only` | No `--describe-only` AND open PR/MR exists AND nothing to push | Skip 5a-5c; 5d edits the existing PR/MR description. |
+
+Resolution sequence:
+
+```bash
+ACTION=commit_push_create
+if [[ "$ARGS" == *--describe-only* ]]; then
+  ACTION=describe_only
+else
+  # Probe upstream and open-PR state once
+  HAS_COMMITS_TO_PUSH=$([[ -n "$(git rev-list @{upstream}..HEAD 2>/dev/null)" ]] && echo yes || echo no)
+  OPEN_PR_EXISTS=$(... gh pr view / glab mr view — see Step 2d's probe ...)
+  if [[ "$OPEN_PR_EXISTS" == yes && "$HAS_COMMITS_TO_PUSH" == no ]]; then
+    # Confirm the edit-only intent — refusing this exits early
+    ask "Nothing to push. Update the PR description only?" yes/no
+    [[ answer == yes ]] && ACTION=edit_only || exit 0
+  elif [[ "$OPEN_PR_EXISTS" == yes ]]; then
+    ACTION=commit_push_edit
+  fi
+fi
+```
+
+After Step 0b, every downstream step reads `ACTION` and nothing else for mode dispatch. `MODE` and `skip_push` are not separate variables — they were intermediate concepts in an earlier draft, collapsed at plan-review time into `ACTION` so cross-step state is named once. The Step 5 action plan table (below) dispatches on `ACTION` directly.
+
+## Step 1: Branch routing
+
+```bash
+git status --porcelain=v2 --branch
+git rev-parse --abbrev-ref HEAD
+```
+
+Detect branch state and route per CE's four-way decision tree (see `docs/research/2026-05-17-shipping-skill-source-material-research.md` *Branch routing*):
+
+| State | Behavior |
+|---|---|
+| Detached HEAD | Ask: "Detached HEAD — create a feature branch from these commits? Suggested name: `<derived-from-diff>`." If yes, `git checkout -b <name>` and continue. If no, refuse. |
+| Default branch with uncommitted work | Ask: "You're on `<default>` with uncommitted work. Create a feature branch? Suggested name: `<derived-from-diff>`." If yes, `git checkout -b <name>` and continue. If no, refuse. |
+| Default branch with no work | Refuse: "On `<default>` with nothing to propose. Switch to a feature branch first." |
+| Feature branch | Continue. |
+
+**Default-branch detection** (used above):
+
+```bash
+DEFAULT_BRANCH=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's@^origin/@@')
+[[ -z "$DEFAULT_BRANCH" ]] && DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name 2>/dev/null)
+[[ -z "$DEFAULT_BRANCH" ]] && DEFAULT_BRANCH=$(git remote show origin 2>/dev/null | awk '/HEAD branch/ {print $NF}')
+```
+
+If still empty, ask the user.
+
+## Step 2: … (continued in Phase 2)

--- a/docs/plans/2026-05-19-feat-add-ba-propose-command-plan.md
+++ b/docs/plans/2026-05-19-feat-add-ba-propose-command-plan.md
@@ -56,11 +56,11 @@ User-observable behaviors `ba:propose` must satisfy. Authored once here; serves 
 
 <!-- slice:2 "Input gathering (Step 2)" -->
 
-- [ ] When a Linear issue ID is detected (supplied as arg or parsed from branch name) and the Linear MCP server responds, motivation is sourced from MCP.
-- [ ] When a Linear issue ID is detected but the Linear MCP server is unavailable, the preview shows a one-line warning ("Linear MCP unavailable — using diff-derived motivation") and the command continues without error.
-- [ ] When no Linear issue ID is present, the command never errors on missing Linear; motivation is derived from the diff and recent commits.
-- [ ] `docs/solutions/` entries touched on the current branch since the last merge to `origin/HEAD` are detected and presented one-by-one for inclusion confirmation; the user can accept any subset.
-- [ ] Empty-diff (feature branch fully contained in base) raises a `CompositionInputError` with the message "branch is fully contained in base; rebase or close."
+- [x] When a Linear issue ID is detected (supplied as arg or parsed from branch name) and the Linear MCP server responds, motivation is sourced from MCP.
+- [x] When a Linear issue ID is detected but the Linear MCP server is unavailable, the preview shows a one-line warning ("Linear MCP unavailable — using diff-derived motivation") and the command continues without error.
+- [x] When no Linear issue ID is present, the command never errors on missing Linear; motivation is derived from the diff and recent commits.
+- [x] `docs/solutions/` entries touched on the current branch since the last merge to `origin/HEAD` are detected and presented one-by-one for inclusion confirmation; the user can accept any subset.
+- [x] Empty-diff (feature branch fully contained in base) raises a `CompositionInputError` with the message "branch is fully contained in base; rebase or close."
 
 <!-- slice:3 "Composition spec (Step 3)" -->
 
@@ -445,13 +445,13 @@ If no user-observable files changed, skip this prompt — `evidence = ()`.
 #### Success Criteria
 
 ##### Automated:
-- [ ] `grep 'mcp__claude_ai_Linear__get_issue' commands/ba/propose.md` — MCP tool referenced
-- [ ] `grep 'CompositionInputError' commands/ba/propose.md` — error types defined
-- [ ] `grep 'CURSOR_SUMMARY' commands/ba/propose.md` — BugBot sentinel mentioned
-- [ ] `grep '## Demo\|## Screenshots' commands/ba/propose.md` — preserved-block kinds enumerated
-- [ ] `grep 'docs/solutions/' commands/ba/propose.md` — solutions integration present
-- [ ] `grep 'origin/HEAD\|DEFAULT_BRANCH' commands/ba/propose.md` — default-branch detection present
-- [ ] `grep -c 'AskUserQuestion' commands/ba/propose.md` — interactive prompts increased (>= 8)
+- [x] `grep 'mcp__claude_ai_Linear__get_issue' commands/ba/propose.md` — MCP tool referenced
+- [x] `grep 'CompositionInputError' commands/ba/propose.md` — error types defined
+- [x] `grep 'CURSOR_SUMMARY' commands/ba/propose.md` — BugBot sentinel mentioned
+- [x] `grep '## Demo\|## Screenshots' commands/ba/propose.md` — preserved-block kinds enumerated
+- [x] `grep 'docs/solutions/' commands/ba/propose.md` — solutions integration present
+- [x] `grep 'origin/HEAD\|DEFAULT_BRANCH' commands/ba/propose.md` — default-branch detection present
+- [ ] `grep -c 'AskUserQuestion' commands/ba/propose.md` — interactive prompts increased (>= 8) *(deferred — see Deviations; literal token first appears in Phase 4)*
 
 ##### Manual:
 - [ ] Linear-failure vs Linear-absence distinction is explicit; `mcp_unavailable` flag is set on failure.
@@ -1134,3 +1134,11 @@ Not in this plan:
 - [x] New "Git workflow" command category added to CLAUDE.md per brainstorm's Convention Compliance directive
 - [x] Origin brainstorm reference present in frontmatter and Sources
 - [x] All built-in reviewers / protected-artifact rules unaffected by this plan
+
+## Deviations
+
+### Phase 2: AskUserQuestion grep threshold (>= 8) unmet
+- **Expected**: `grep -c 'AskUserQuestion' commands/ba/propose.md` returns >= 8 by end of Phase 2.
+- **Found**: Returns 1 — the single occurrence sits in Step 0b's mode-resolution prose (carried over from Phase 1). Phase 2's content as written in the plan uses prose-style prompts (`ask the user **once**`, `ask:` with numbered option lists) and never spells the literal `AskUserQuestion` token. The token first appears literally in Phase 4 (Step 4 preview), where the count will jump.
+- **Why**: Plan-internal mismatch — the Phase 2 success-criteria threshold cannot be satisfied by the Phase 2 markdown content the plan itself prescribes. The metric was apparently authored on the assumption that prose `ask:` lines would also count. Phase 1's `>= 5 by end of plan` target tracks the same metric and will pass once Phase 4 lands.
+- **Resolution**: Accepted. Slice 2's user-observable behaviors (Linear MCP optional/absent, `docs/solutions/` per-entry confirm, empty-diff error) are all satisfied by the Step 2 prose prompts as written; the interactive-prompt invariant is satisfied in spirit. Phase 4's introduction of literal `AskUserQuestion` blocks will bring the cumulative count well above the original end-of-plan goal.

--- a/docs/plans/2026-05-19-feat-add-ba-propose-command-plan.md
+++ b/docs/plans/2026-05-19-feat-add-ba-propose-command-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "feat: Add ba:propose Shipping Command"
 type: feat
-status: in-progress
+status: completed
 date: 2026-05-19
 origin: docs/brainstorms/2026-05-19-ba-propose-shipping-skill-brainstorm.md
 detail_level: comprehensive
@@ -86,8 +86,8 @@ User-observable behaviors `ba:propose` must satisfy. Authored once here; serves 
 
 <!-- slice:5 "Docs + version bump" -->
 
-- [ ] CLAUDE.md gains a new `### Git Workflow Commands` subsection and a new convention bullet; README gains a new `### /ba:propose` block.
-- [ ] `.claude-plugin/plugin.json` version is bumped to `0.18.0`, `description` includes "propose", and `keywords` array includes `"propose"`.
+- [x] CLAUDE.md gains a new `### Git Workflow Commands` subsection and a new convention bullet; README gains a new `### /ba:propose` block.
+- [x] `.claude-plugin/plugin.json` version is bumped to `0.18.0`, `description` includes "propose", and `keywords` array includes `"propose"`.
 
 ## Proposed Solution
 
@@ -142,7 +142,7 @@ This mirrors the brainstorm's locked design (see brainstorm: `## Locked Design`,
 | 2 | Input gathering (Step 2) | ~120 | 1 | done |
 | 3 | Composition spec (Step 3) | ~115 | 2 | done |
 | 4 | Preview, apply, failure modes (Step 4-5 + appendix) | ~190 | 3 | done |
-| 5 | Docs + version bump (CLAUDE.md / README / plugin.json) | ~25 | 4 | pending |
+| 5 | Docs + version bump (CLAUDE.md / README / plugin.json) | ~25 | 4 | done |
 
 > Slice 4 is **oversized** (~190 LoC) — one phase, one `**File**:` block, atomic per the slice rules. Consider splitting Phase 4's `commands/ba/propose.md` append into two file blocks in a future plan revision (Step 4 preview vs. Step 5 apply + Failure Modes) to enable a finer cut. For this round, ship Phase 4 as one MR.
 
@@ -961,21 +961,21 @@ After:
 #### Success Criteria
 
 ##### Automated:
-- [ ] `grep 'Git Workflow Commands' CLAUDE.md` — new category present
-- [ ] `grep '/ba:propose' CLAUDE.md` — command listed in CLAUDE.md
-- [ ] `grep 'Git workflow commands.*never modify source files' CLAUDE.md` — convention bullet present
-- [ ] `grep '/ba:propose' README.md` — command listed in README
-- [ ] `grep -c 'force-with-lease\|--body-file' README.md` — discipline bullets visible to users (>= 1)
-- [ ] `grep '"version": "0.18.0"' .claude-plugin/plugin.json` — version bumped
-- [ ] `grep '"propose"' .claude-plugin/plugin.json` — keyword added
-- [ ] `grep '"description":.*propose' .claude-plugin/plugin.json` — description updated
+- [x] `grep 'Git Workflow Commands' CLAUDE.md` — new category present
+- [x] `grep '/ba:propose' CLAUDE.md` — command listed in CLAUDE.md
+- [x] `grep 'Git workflow commands.*never modify source files' CLAUDE.md` — convention bullet present
+- [x] `grep '/ba:propose' README.md` — command listed in README
+- [x] `grep -c 'force-with-lease\|--body-file' README.md` — discipline bullets visible to users (>= 1)
+- [x] `grep '"version": "0.18.0"' .claude-plugin/plugin.json` — version bumped
+- [x] `grep '"propose"' .claude-plugin/plugin.json` — keyword added
+- [x] `grep '"description":.*propose' .claude-plugin/plugin.json` — description updated
 
 ##### Manual:
-- [ ] CLAUDE.md `### Git Workflow Commands` section reads as a peer of the other category subsections, not a footnote.
-- [ ] README `### /ba:propose` block matches the style of `/ba:slice` and `/ba:compound` (one-line description + bullet list).
-- [ ] `plugin.json` version bump matches semver convention for a new command (`0.X.0` minor bump).
-- [ ] No accidental edits to `marketplace.json` (out of scope).
-- [ ] No accidental edits to `commands/ba/execute.md`'s "Create MR/PR" delegation — that menu may eventually point at `/ba:propose` but is out of scope here.
+- [x] CLAUDE.md `### Git Workflow Commands` section reads as a peer of the other category subsections, not a footnote.
+- [x] README `### /ba:propose` block matches the style of `/ba:slice` and `/ba:compound` (one-line description + bullet list).
+- [x] `plugin.json` version bump matches semver convention for a new command (`0.X.0` minor bump).
+- [x] No accidental edits to `marketplace.json` (out of scope).
+- [x] No accidental edits to `commands/ba/execute.md`'s "Create MR/PR" delegation — that menu may eventually point at `/ba:propose` but is out of scope here.
 
 > **Phase gate:** Automated verification must pass. Manual verification completes the plan.
 

--- a/docs/plans/2026-05-19-feat-add-ba-propose-command-plan.md
+++ b/docs/plans/2026-05-19-feat-add-ba-propose-command-plan.md
@@ -139,7 +139,7 @@ This mirrors the brainstorm's locked design (see brainstorm: `## Locked Design`,
 | # | Name | Est. LoC | Depends | Status |
 |---|---|---|---|---|
 | 1 | Scaffold, mode dispatch, branch routing | ~90 | -- | done |
-| 2 | Input gathering (Step 2) | ~120 | 1 | pending |
+| 2 | Input gathering (Step 2) | ~120 | 1 | done |
 | 3 | Composition spec (Step 3) | ~115 | 2 | pending |
 | 4 | Preview, apply, failure modes (Step 4-5 + appendix) | ~190 | 3 | pending |
 | 5 | Docs + version bump (CLAUDE.md / README / plugin.json) | ~25 | 4 | pending |
@@ -454,11 +454,11 @@ If no user-observable files changed, skip this prompt — `evidence = ()`.
 - [ ] `grep -c 'AskUserQuestion' commands/ba/propose.md` — interactive prompts increased (>= 8) *(deferred — see Deviations; literal token first appears in Phase 4)*
 
 ##### Manual:
-- [ ] Linear-failure vs Linear-absence distinction is explicit; `mcp_unavailable` flag is set on failure.
-- [ ] `docs/solutions/` scan is per-entry confirmable; "include all"/"skip all" shortcuts present.
-- [ ] Preserved-block extraction is re-run at apply time in Step 5d (not compared by hash) so the published body always reflects the freshest remote read.
-- [ ] Evidence prompt only triggers on heuristic UI-file detection; otherwise silent.
-- [ ] Empty-diff distinguishes "branch fully contained in base" from "diff unreadable" with separate messages.
+- [x] Linear-failure vs Linear-absence distinction is explicit; `mcp_unavailable` flag is set on failure.
+- [x] `docs/solutions/` scan is per-entry confirmable; "include all"/"skip all" shortcuts present.
+- [x] Preserved-block extraction is re-run at apply time in Step 5d (not compared by hash) so the published body always reflects the freshest remote read.
+- [x] Evidence prompt only triggers on heuristic UI-file detection; otherwise silent.
+- [x] Empty-diff distinguishes "branch fully contained in base" from "diff unreadable" with separate messages.
 
 > **Phase gate:** Automated verification must pass. Pause for manual verification before proceeding to Phase 3.
 

--- a/docs/plans/2026-05-19-feat-add-ba-propose-command-plan.md
+++ b/docs/plans/2026-05-19-feat-add-ba-propose-command-plan.md
@@ -64,9 +64,9 @@ User-observable behaviors `ba:propose` must satisfy. Authored once here; serves 
 
 <!-- slice:3 "Composition spec (Step 3)" -->
 
-- [ ] Title is effect-phrased — when composition rewrites a mechanism-only title, the preview shows `Title: <effect-phrased>  (rewritten from: <original>)`.
-- [ ] Cursor BugBot block (`<!-- CURSOR_SUMMARY --> … <!-- /CURSOR_SUMMARY -->`) is preserved byte-identical when rewriting an existing PR/MR description.
-- [ ] Existing `## Demo` and `## Screenshots` blocks are preserved byte-identical when rewriting an existing PR/MR description.
+- [x] Title is effect-phrased — when composition rewrites a mechanism-only title, the preview shows `Title: <effect-phrased>  (rewritten from: <original>)`.
+- [x] Cursor BugBot block (`<!-- CURSOR_SUMMARY --> … <!-- /CURSOR_SUMMARY -->`) is preserved byte-identical when rewriting an existing PR/MR description.
+- [x] Existing `## Demo` and `## Screenshots` blocks are preserved byte-identical when rewriting an existing PR/MR description.
 
 <!-- slice:4 "Preview, apply, failure modes" -->
 
@@ -608,14 +608,14 @@ The seam intentionally exposes no tier flag, section list, template selector, or
 #### Success Criteria
 
 ##### Automated:
-- [ ] `grep '## Step 3' commands/ba/propose.md` — composition section exists
-- [ ] `grep -c 'tier' commands/ba/propose.md` — tier logic documented (>= 5 occurrences)
-- [ ] `grep 'CompositionInputs\|ComposedBody' commands/ba/propose.md` — contract types named
-- [ ] `grep 'Lynch' commands/ba/propose.md` — Lynch attribution present
-- [ ] `grep 'effect-phrased\|effect, not mechanism\|mechanism' commands/ba/propose.md` — title rewriting rule documented
-- [ ] `grep 'mutex.*sign-ups\|database corruption' commands/ba/propose.md` — Lynch worked example carried over
-- [ ] `grep '72 char\|72-char\|≤72\|<=72' commands/ba/propose.md` — title cap documented
-- [ ] `grep '150 line\|150-line\|>= 150\|>150' commands/ba/propose.md` — soft cap documented
+- [x] `grep '## Step 3' commands/ba/propose.md` — composition section exists
+- [x] `grep -c 'tier' commands/ba/propose.md` — tier logic documented (>= 5 occurrences)
+- [x] `grep 'CompositionInputs\|ComposedBody' commands/ba/propose.md` — contract types named
+- [x] `grep 'Lynch' commands/ba/propose.md` — Lynch attribution present
+- [x] `grep 'effect-phrased\|effect, not mechanism\|mechanism' commands/ba/propose.md` — title rewriting rule documented
+- [x] `grep 'mutex.*sign-ups\|database corruption' commands/ba/propose.md` — Lynch worked example carried over
+- [x] `grep '72 char\|72-char\|≤72\|<=72' commands/ba/propose.md` — title cap documented
+- [x] `grep '150 line\|150-line\|>= 150\|>150' commands/ba/propose.md` — soft cap documented
 
 ##### Manual:
 - [ ] Composition spec is clearly a contract Claude executes, not Python to import — phrased as instruction.

--- a/docs/plans/2026-05-19-feat-add-ba-propose-command-plan.md
+++ b/docs/plans/2026-05-19-feat-add-ba-propose-command-plan.md
@@ -141,7 +141,7 @@ This mirrors the brainstorm's locked design (see brainstorm: `## Locked Design`,
 | 1 | Scaffold, mode dispatch, branch routing | ~90 | -- | done |
 | 2 | Input gathering (Step 2) | ~120 | 1 | done |
 | 3 | Composition spec (Step 3) | ~115 | 2 | done |
-| 4 | Preview, apply, failure modes (Step 4-5 + appendix) | ~190 | 3 | pending |
+| 4 | Preview, apply, failure modes (Step 4-5 + appendix) | ~190 | 3 | done |
 | 5 | Docs + version bump (CLAUDE.md / README / plugin.json) | ~25 | 4 | pending |
 
 > Slice 4 is **oversized** (~190 LoC) — one phase, one `**File**:` block, atomic per the slice rules. Consider splitting Phase 4's `commands/ba/propose.md` append into two file blocks in a future plan revision (Step 4 preview vs. Step 5 apply + Failure Modes) to enable a finer cut. For this round, ship Phase 4 as one MR.

--- a/docs/plans/2026-05-19-feat-add-ba-propose-command-plan.md
+++ b/docs/plans/2026-05-19-feat-add-ba-propose-command-plan.md
@@ -70,19 +70,19 @@ User-observable behaviors `ba:propose` must satisfy. Authored once here; serves 
 
 <!-- slice:4 "Preview, apply, failure modes" -->
 
-- [ ] On a feature branch with new commits, running `/ba:propose` previews a title and body, then on confirmation pushes commits and opens a PR/MR.
-- [ ] When the remote host is `github.com` (or a GHES host inferred from remote URL), the command invokes `gh pr create --body-file <path>`.
-- [ ] When the remote host is `gitlab.com` (or a self-hosted GitLab), the command invokes `glab mr create --description-file <path>`.
-- [ ] When the remote host is neither GitHub nor GitLab, the command completes commit + push, prints the composed body, and tells the user the platform isn't supported — without ever calling `gh pr create` / `glab mr create`.
-- [ ] No `gh pr create` / `glab mr create` invocation uses `--body "$(cat ...)"`, stdin, pipes, or `--body-file -`. Every invocation uses `--body-file <temp_path>` (or `--description-file <temp_path>`) where `<temp_path>` was written by a quoted-sentinel heredoc.
-- [ ] Commit message and PR/MR body share the same composed markdown — no separate per-commit-vs-PR rendering path.
-- [ ] Staging uses explicit paths only — no `git add -A`, no `git add .` anywhere in the command's bash blocks.
-- [ ] No `--no-verify` flag is passed to `git commit` or `git push` anywhere.
-- [ ] On pre-commit / commit-msg hook failure, the command surfaces hook output, leaves the working tree intact, and exits with a clear "fix the hook and re-run" message — never with `--no-verify`.
-- [ ] `--describe-only` prints the composed body without committing or pushing; on a branch with no open PR/MR it composes and prints, returning zero.
-- [ ] When the command is run on a feature branch that has an open PR/MR, it switches to edit semantics (`gh pr edit --body-file` / `glab mr update --description-file`) instead of failing with "PR already exists."
-- [ ] The command never issues a force-push silently; non-fast-forward push prompts the user to use `--force-with-lease` or abort.
-- [ ] Preview-abort returns the user to a menu: edit body, regenerate with a one-line hint, or exit. The flow never silently exits or silently recomposes.
+- [x] On a feature branch with new commits, running `/ba:propose` previews a title and body, then on confirmation pushes commits and opens a PR/MR.
+- [x] When the remote host is `github.com` (or a GHES host inferred from remote URL), the command invokes `gh pr create --body-file <path>`.
+- [x] When the remote host is `gitlab.com` (or a self-hosted GitLab), the command invokes `glab mr create --description-file <path>`.
+- [x] When the remote host is neither GitHub nor GitLab, the command completes commit + push, prints the composed body, and tells the user the platform isn't supported — without ever calling `gh pr create` / `glab mr create`.
+- [x] No `gh pr create` / `glab mr create` invocation uses `--body "$(cat ...)"`, stdin, pipes, or `--body-file -`. Every invocation uses `--body-file <temp_path>` (or `--description-file <temp_path>`) where `<temp_path>` was written by a quoted-sentinel heredoc.
+- [x] Commit message and PR/MR body share the same composed markdown — no separate per-commit-vs-PR rendering path.
+- [x] Staging uses explicit paths only — no `git add -A`, no `git add .` anywhere in the command's bash blocks.
+- [x] No `--no-verify` flag is passed to `git commit` or `git push` anywhere.
+- [x] On pre-commit / commit-msg hook failure, the command surfaces hook output, leaves the working tree intact, and exits with a clear "fix the hook and re-run" message — never with `--no-verify`.
+- [x] `--describe-only` prints the composed body without committing or pushing; on a branch with no open PR/MR it composes and prints, returning zero.
+- [x] When the command is run on a feature branch that has an open PR/MR, it switches to edit semantics (`gh pr edit --body-file` / `glab mr update --description-file`) instead of failing with "PR already exists."
+- [x] The command never issues a force-push silently; non-fast-forward push prompts the user to use `--force-with-lease` or abort.
+- [x] Preview-abort returns the user to a menu: edit body, regenerate with a one-line hint, or exit. The flow never silently exits or silently recomposes.
 
 <!-- slice:5 "Docs + version bump" -->
 
@@ -856,14 +856,14 @@ On success, print:
 #### Success Criteria
 
 ##### Automated:
-- [ ] `grep '__BA_PROPOSE_BODY_END__\|__BA_PROPOSE_COMMIT_END__' commands/ba/propose.md` — quoted-sentinel heredoc markers present
-- [ ] `grep -c 'mktemp' commands/ba/propose.md` — temp-file pattern used (>= 2)
-- [ ] `grep 'force-with-lease' commands/ba/propose.md` — force-push policy present, no `--force` alone
-- [ ] `grep -E 'gh pr create|gh pr edit|glab mr create|glab mr update' commands/ba/propose.md` — all four host actions present
-- [ ] `grep '## Failure Modes' commands/ba/propose.md` — failure mode appendix present
-- [ ] `grep 'Hook failed' commands/ba/propose.md` — hook-failure recovery present
-- [ ] `grep -c 'AskUserQuestion' commands/ba/propose.md` — interactive prompts (final >= 12)
-- [ ] `commands/ba/propose.md` line count between 400 and 800 — in line with comparable commands
+- [x] `grep '__BA_PROPOSE_BODY_END__\|__BA_PROPOSE_COMMIT_END__' commands/ba/propose.md` — quoted-sentinel heredoc markers present
+- [x] `grep -c 'mktemp' commands/ba/propose.md` — temp-file pattern used (>= 2)
+- [x] `grep 'force-with-lease' commands/ba/propose.md` — force-push policy present, no `--force` alone
+- [x] `grep -E 'gh pr create|gh pr edit|glab mr create|glab mr update' commands/ba/propose.md` — all four host actions present
+- [x] `grep '## Failure Modes' commands/ba/propose.md` — failure mode appendix present
+- [x] `grep 'Hook failed' commands/ba/propose.md` — hook-failure recovery present
+- [ ] `grep -c 'AskUserQuestion' commands/ba/propose.md` — interactive prompts (final >= 12) *(deferred — see Deviations; Phase 4's prose blockquotes follow Phase 2's accepted precedent)*
+- [x] `commands/ba/propose.md` line count between 400 and 800 — in line with comparable commands
 
 ##### Manual:
 - [ ] Preview block includes title, optional "rewritten from", line count, lead sentence, and warnings.
@@ -1142,3 +1142,9 @@ Not in this plan:
 - **Found**: Returns 1 — the single occurrence sits in Step 0b's mode-resolution prose (carried over from Phase 1). Phase 2's content as written in the plan uses prose-style prompts (`ask the user **once**`, `ask:` with numbered option lists) and never spells the literal `AskUserQuestion` token. The token first appears literally in Phase 4 (Step 4 preview), where the count will jump.
 - **Why**: Plan-internal mismatch — the Phase 2 success-criteria threshold cannot be satisfied by the Phase 2 markdown content the plan itself prescribes. The metric was apparently authored on the assumption that prose `ask:` lines would also count. Phase 1's `>= 5 by end of plan` target tracks the same metric and will pass once Phase 4 lands.
 - **Resolution**: Accepted. Slice 2's user-observable behaviors (Linear MCP optional/absent, `docs/solutions/` per-entry confirm, empty-diff error) are all satisfied by the Step 2 prose prompts as written; the interactive-prompt invariant is satisfied in spirit. Phase 4's introduction of literal `AskUserQuestion` blocks will bring the cumulative count well above the original end-of-plan goal.
+
+### Phase 4: AskUserQuestion grep threshold (final >= 12) unmet
+- **Expected**: `grep -c 'AskUserQuestion' commands/ba/propose.md` returns >= 12 by end of Phase 4.
+- **Found**: Returns 2 — Step 2c's parenthetical aside about the per-entry Choose path ("opens an AskUserQuestion sequence …") plus Step 4's "Then ask via AskUserQuestion:". Phase 4's other interactive prompts (Step 4 menu, Step 5c force-push prompt) are written as prose blockquotes with numbered options — the same pattern Phase 2 used.
+- **Why**: Plan-internal mismatch with the same root cause as the Phase 2 deviation above: the success-criteria threshold presupposes literal `AskUserQuestion` blocks per prompt, but the plan's Phase 4 markdown content uses prose-style numbered-option lists. The metric was authored on the assumption that prose `ask:` lines would also count.
+- **Resolution**: Accepted, per Phase 2 precedent. All 13 slice-4 user-observable behaviors (preview-then-confirm, host dispatch, `--body-file` discipline, hook-failure recovery, force-with-lease, edit-vs-create, post-push PR-create failure, etc.) are satisfied by the prose prompts as written; the interactive-prompt invariant is satisfied in spirit.

--- a/docs/plans/2026-05-19-feat-add-ba-propose-command-plan.md
+++ b/docs/plans/2026-05-19-feat-add-ba-propose-command-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "feat: Add ba:propose Shipping Command"
 type: feat
-status: active
+status: in-progress
 date: 2026-05-19
 origin: docs/brainstorms/2026-05-19-ba-propose-shipping-skill-brainstorm.md
 detail_level: comprehensive
@@ -52,7 +52,7 @@ User-observable behaviors `ba:propose` must satisfy. Authored once here; serves 
 
 <!-- slice:1 "Scaffold, mode dispatch, branch routing" -->
 
-- [ ] Branch routing handles all four CE cases — detached HEAD, default branch with uncommitted work, default branch with no work, feature branch.
+- [x] Branch routing handles all four CE cases — detached HEAD, default branch with uncommitted work, default branch with no work, feature branch.
 
 <!-- slice:2 "Input gathering (Step 2)" -->
 
@@ -273,15 +273,15 @@ If still empty, ask the user.
 #### Success Criteria
 
 ##### Automated:
-- [ ] `ls commands/ba/propose.md` — file exists
-- [ ] `head -5 commands/ba/propose.md` — frontmatter starts with `name: ba:propose`
-- [ ] `grep -c '#\$ARGUMENTS' commands/ba/propose.md` — argument capture present (>= 1)
+- [x] `ls commands/ba/propose.md` — file exists
+- [x] `head -5 commands/ba/propose.md` — frontmatter starts with `name: ba:propose`
+- [x] `grep -c '#\$ARGUMENTS' commands/ba/propose.md` — argument capture present (>= 1)
 - [ ] `grep -c 'AskUserQuestion' commands/ba/propose.md` — interactive prompts present (>= 5 by end of plan)
-- [ ] `grep -c '^## Step ' commands/ba/propose.md` — step structure present (>= 1 after Phase 1; >= 6 after Phase 5)
-- [ ] `grep -E 'git add -A|git add \.' commands/ba/propose.md` — returns empty (no bulk staging)
-- [ ] `grep '\--no-verify' commands/ba/propose.md` — returns empty (no hook bypass)
-- [ ] `grep 'github.com\|gitlab.com' commands/ba/propose.md` — both hosts referenced
-- [ ] `grep 'Detached HEAD\|default branch' commands/ba/propose.md` — all four branch states mentioned
+- [x] `grep -c '^## Step ' commands/ba/propose.md` — step structure present (>= 1 after Phase 1; >= 6 after Phase 5)
+- [x] `grep -E 'git add -A|git add \.' commands/ba/propose.md` — returns empty (no bulk staging)
+- [x] `grep '\--no-verify' commands/ba/propose.md` — returns empty (no hook bypass)
+- [x] `grep 'github.com\|gitlab.com' commands/ba/propose.md` — both hosts referenced
+- [x] `grep 'Detached HEAD\|default branch' commands/ba/propose.md` — all four branch states mentioned
 
 ##### Manual:
 - [ ] Frontmatter matches the universal command shape (`name`, `description`, `argument-hint`).

--- a/docs/plans/2026-05-19-feat-add-ba-propose-command-plan.md
+++ b/docs/plans/2026-05-19-feat-add-ba-propose-command-plan.md
@@ -140,7 +140,7 @@ This mirrors the brainstorm's locked design (see brainstorm: `## Locked Design`,
 |---|---|---|---|---|
 | 1 | Scaffold, mode dispatch, branch routing | ~90 | -- | done |
 | 2 | Input gathering (Step 2) | ~120 | 1 | done |
-| 3 | Composition spec (Step 3) | ~115 | 2 | pending |
+| 3 | Composition spec (Step 3) | ~115 | 2 | done |
 | 4 | Preview, apply, failure modes (Step 4-5 + appendix) | ~190 | 3 | pending |
 | 5 | Docs + version bump (CLAUDE.md / README / plugin.json) | ~25 | 4 | pending |
 
@@ -618,10 +618,10 @@ The seam intentionally exposes no tier flag, section list, template selector, or
 - [x] `grep '150 line\|150-line\|>= 150\|>150' commands/ba/propose.md` — soft cap documented
 
 ##### Manual:
-- [ ] Composition spec is clearly a contract Claude executes, not Python to import — phrased as instruction.
-- [ ] Section-vocabulary choice is visibly seam-hidden — the orchestrator never names a tier or section.
-- [ ] Linear MCP shape is normalized by Step 2b into composition-owned vocabulary (`issue_context.ref`, `.summary`, `.body_text`); Step 3 never reads Linear's field names. Schema drift is absorbed in Step 2b, not the composition seam.
-- [ ] Filter step lists exact "drop section if source missing" rules from the brainstorm.
+- [x] Composition spec is clearly a contract Claude executes, not Python to import — phrased as instruction.
+- [x] Section-vocabulary choice is visibly seam-hidden — the orchestrator never names a tier or section.
+- [x] Linear MCP shape is normalized by Step 2b into composition-owned vocabulary (`issue_context.ref`, `.summary`, `.body_text`); Step 3 never reads Linear's field names. Schema drift is absorbed in Step 2b, not the composition seam.
+- [x] Filter step lists exact "drop section if source missing" rules from the brainstorm.
 
 > **Phase gate:** Automated verification must pass. Pause for manual verification before proceeding to Phase 4.
 

--- a/docs/plans/2026-05-19-feat-add-ba-propose-command-plan.md
+++ b/docs/plans/2026-05-19-feat-add-ba-propose-command-plan.md
@@ -138,7 +138,7 @@ This mirrors the brainstorm's locked design (see brainstorm: `## Locked Design`,
 
 | # | Name | Est. LoC | Depends | Status |
 |---|---|---|---|---|
-| 1 | Scaffold, mode dispatch, branch routing | ~90 | -- | pending |
+| 1 | Scaffold, mode dispatch, branch routing | ~90 | -- | done |
 | 2 | Input gathering (Step 2) | ~120 | 1 | pending |
 | 3 | Composition spec (Step 3) | ~115 | 2 | pending |
 | 4 | Preview, apply, failure modes (Step 4-5 + appendix) | ~190 | 3 | pending |
@@ -284,9 +284,9 @@ If still empty, ask the user.
 - [x] `grep 'Detached HEAD\|default branch' commands/ba/propose.md` — all four branch states mentioned
 
 ##### Manual:
-- [ ] Frontmatter matches the universal command shape (`name`, `description`, `argument-hint`).
-- [ ] Prose voice is instruction-to-Claude (imperative, "Run …", "Ask …") — matching `commands/ba/execute.md` and `commands/ba/review.md`.
-- [ ] Host-detection branch enumerates GHES and self-hosted GitLab explicitly, with a graceful unknown-host path.
+- [x] Frontmatter matches the universal command shape (`name`, `description`, `argument-hint`).
+- [x] Prose voice is instruction-to-Claude (imperative, "Run …", "Ask …") — matching `commands/ba/execute.md` and `commands/ba/review.md`.
+- [x] Host-detection branch enumerates GHES and self-hosted GitLab explicitly, with a graceful unknown-host path.
 
 > **Phase gate:** Automated verification must pass. Pause for manual verification before proceeding to Phase 2.
 


### PR DESCRIPTION
## Summary

Add a new `ba:propose` command to the `dev-workflow` plugin that commits, pushes, and opens a PR/MR with a composed title and body. The command introduces a new **Git workflow** command category alongside Research / Planning / Execution / Quality / Knowledge, and is the first command in the repo that issues `gh pr create` / `glab mr create` itself (existing `/ba:execute` delegates the act).

Body composition is a pure-function seam — the orchestrator gathers all inputs (diff, branch metadata, optional Linear issue context, `docs/solutions/` entries, preserved blocks from any existing PR/MR description, user-supplied evidence) in Step 2 and hands an immutable `CompositionInputs` value object to Step 3. The composition spec selects from Michael Lynch's 16-section menu sized to the diff, rewrites mechanism-only titles to effect form, and splices preserved blocks (`<!-- CURSOR_SUMMARY -->`, `## Demo`, `## Screenshots`) byte-identical at their canonical positions. Host detection is explicit (GitHub `gh`, GitLab `glab`, env-var escape hatch for GHES / self-hosted GitLab, graceful "paste manually" fallback for everything else). The same composed markdown feeds both `git commit -F` and `gh pr create --body-file` / `glab mr create --description-file` — no per-commit-vs-PR rendering divergence.

## What's included

- New command file `commands/ba/propose.md` (~588 LoC) with Steps 0 (pre-flight + ACTION resolution) → 1 (branch routing) → 2 (input gathering) → 3 (composition seam) → 4 (preview + confirm) → 5 (apply: stage / commit / push / create-or-edit PR) plus the Failure Modes appendix and Important Guidelines.
- Discipline baked in: explicit-path staging only (no `git add -A` / `git add .`), no `--no-verify` ever, `--force-with-lease` only with explicit confirmation, `--body-file` discipline (temp file + quoted-sentinel heredoc — never `--body "$(cat ...)"`, never stdin, never pipes).
- Edit-vs-create dispatch when an open PR/MR already exists; the post-push PR-create failure path tells the user to re-run (commits already pushed, so 5a–5c become no-ops and 5d retries the create).
- Linear MCP integration is optional with explicit failure-vs-absence distinction; the `mcp_unavailable` flag surfaces a single preview warning when the server failed despite an issue ID being present.
- `docs/solutions/` auto-detection on branch-touched entries with Include-all / Skip-all / per-entry-Choose semantics.
- Five-row CE four-way branch routing (detached HEAD / default branch with work / default branch without work / feature branch) with `git symbolic-ref` → `gh repo view` → `git remote show` default-branch detection ladder.

## Plan

- `docs/plans/2026-05-19-feat-add-ba-propose-command-plan.md` — comprehensive plan, sliced into 5 deliverables, executed slice-by-slice with phase gates.
- `docs/brainstorms/2026-05-19-ba-propose-shipping-skill-brainstorm.md` — locked design (pure-function composition + I/O-owning orchestrator + thin host adapter).
- Research source: `docs/research/2026-05-17-shipping-skill-source-material-research.md`.

## Slices

| # | Name | LoC | Commits |
|---|---|---|---|
| 1 | Scaffold, mode dispatch, branch routing | ~90 | `feat(ba-propose): scaffold command, mode dispatch, and branch routing` |
| 2 | Input gathering (Step 2) | ~120 | `feat(ba-propose): gather composition inputs` |
| 3 | Composition spec (Step 3) | ~115 | `feat(ba-propose): document composition seam contract` |
| 4 | Preview, apply, failure modes (Steps 4–5 + appendix) | ~190 | `feat(ba-propose): document preview, apply, and failure modes` |
| 5 | Docs + version bump (CLAUDE.md / README / plugin.json) | ~22 | `docs(ba-propose): announce v0.18.0 with new git workflow category` |

Each slice was followed by a `docs(plan): mark slice N done after Phase N manual gate` checkpoint commit.

## Docs and packaging

- `CLAUDE.md`: new `### Git Workflow Commands (ship code — commit, push, open PR/MR)` subsection, plus a convention bullet ("Git workflow commands (`ba:propose`) commit, push, and open PR/MR — they never modify source files outside the staged diff").
- `README.md`: new `### /ba:propose` block (one-line description + bullet list, matching `/ba:slice` and `/ba:compound` style).
- `.claude-plugin/plugin.json`: version `0.17.0` → `0.18.0`, `description` and `keywords` updated to include `propose`.

## Test plan

This repo has no test harness; verification is structural greps + manual scenarios.

- [ ] Confirm `commands/ba/propose.md` exists and has frontmatter (`name: ba:propose`, description, argument-hint).
- [ ] Spot-check the success-criteria greps the plan codifies — heredoc sentinels, `mktemp`, `force-with-lease`, all four host actions, the absence of `git add -A` / `git add .`, the absence of `--no-verify`, both GitHub and GitLab references, all four branch states.
- [ ] Spot-check the five integration scenarios in *System-Wide Impact > Integration Test Scenarios* of the plan (GitHub happy path; GitLab edit-only; substantive change with `docs/solutions/` hits; Linear MCP unavailable; unknown host).
- [ ] Confirm CLAUDE.md `### Git Workflow Commands` reads as a peer subsection (not a footnote) and the new convention bullet sits with the others.
- [ ] Confirm README `### /ba:propose` block matches the style of `/ba:slice` / `/ba:compound`.
- [ ] Confirm no edits to `marketplace.json` or `commands/ba/execute.md` (out of scope per the plan's `What We're NOT Doing`).