### PR TITLE
feat(hooks): add comment-guard PostToolUse hook

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-workflow",
-  "version": "0.24.1",
+  "version": "0.25.0",
   "description": "Research, brainstorm, plan, slice, execute, review, compound, and propose commands with triage, convention compliance, and knowledge compounding",
   "author": {
     "name": "Bruno Azevedo"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,10 @@ Claude Code plugin providing brainstorm and plan commands with triage, conventio
 - `plan-iteration-gate` — Per-round plan-iteration discipline validation, dispatched by `/ba:review-plan` Step 5.5 (Read, Grep, Glob, LS)
 - `interface-design-generator` — Generates one alternative interface design under a named Ousterhout-flavored constraint, dispatched in parallel by `/ba:brainstorm` Phase 2 design-it-twice mode (Read, Grep, Glob, LS)
 
+## Hooks
+
+- `comment-guard` (`hooks/hooks.json` → `scripts/comment-guard.sh`) — `PostToolUse` hook on `Edit`/`Write`/`MultiEdit`. When an edit to a code file adds full-line comments, it injects a system reminder listing those lines and re-asserts the why-comments-only convention; silent otherwise. Enforces comment discipline at write time rather than as a deferrable `/ba:review` nit. Tunable via `COMMENT_GUARD_MIN_COMMENTS` (default 2). Scope: code files only — prose/config (`.md`, `.json`, `.yaml`) skipped. Fail-safe: exits silently without `jq` or on unexpected input.
+
 ## Artifact Paths
 
 | Artifact | Path |
@@ -82,3 +86,4 @@ Claude Code plugin providing brainstorm and plan commands with triage, conventio
 - Plan documents default to **decisions** (approach, exact file paths, patterns, pseudo-code for shape, test scenarios); a literal code block is permitted only under a `**Code-shape decision:** <why>` label. The label wording is mirrored across `commands/ba/plan.md` ("Key rules for all templates" trigger block **and** the three template placeholders), `commands/ba/execute.md` (Step 2b + Step 1.5b LoC projection), `commands/ba/slice.md` (LoC Counting Rules), and `README.md` (`/ba:plan` description) — keep them in sync. (This convention covers the *label* only; the `## Locked Design` anchor it references is owned by `commands/ba/brainstorm.md`.)
 - Update README.md whenever commands, agents, or artifact paths are added or changed
 - Git workflow commands (`ba:propose`) commit, push, and open PR/MR — they never modify source files outside the staged diff
+- Plugin hooks live in `hooks/hooks.json` (auto-discovered) and reference scripts under `scripts/` via `${CLAUDE_PLUGIN_ROOT}`; hook scripts must fail safe (exit 0 on missing deps or unexpected input) so they never disrupt an edit. Document new hooks in both `README.md` (Hooks section) and the CLAUDE.md Hooks section.

--- a/README.md
+++ b/README.md
@@ -261,6 +261,20 @@ Research docs (`docs/research/`) are exempt from compliance checks — they are 
 | `plan-iteration-gate` | Validates each `/ba:review-plan` round against the planning-YAGNI / confidence-chasing ratchet — silent when iteration is clean, vocal on six trigger categories, advisory only |
 | `interface-design-generator` | Generates one alternative interface design under a named Ousterhout-flavored constraint (deepest-module / common-case / info-hiding); dispatched in parallel by `/ba:brainstorm` Phase 2 when the brainstorm proposes a new module or interface |
 
+## Hooks
+
+The plugin ships a `PostToolUse` hook (`hooks/hooks.json` → `scripts/comment-guard.sh`) that enforces comment discipline **at write time** instead of leaving it to a deferrable review nit.
+
+| Hook | Trigger | Behavior |
+|---|---|---|
+| `comment-guard` | After `Edit` / `Write` / `MultiEdit` on a code file | If the edit added full-line comments, injects a system reminder listing those exact lines and re-asserts the why-comments-only convention. Silent when no comments were added. |
+
+Why a hook rather than another memory-file instruction: a rule in `CLAUDE.md` loses salience deep in a long edit session, and an end-of-run reviewer flags verbose comments only as a `Low` nit that's easy to skip. The hook fires deterministically on the just-written diff — the one moment the reminder is both salient and cheap to act on. It does the mechanical half (which lines are comments) and hands the judgment half (why-comment vs. restating) back to Claude on a small, fresh diff.
+
+- **Scope:** code files only (`.js/.ts/.go/.py/.rb/.rs/.sh/...`). Prose and config (`.md`, `.json`, `.yaml`) are skipped. Block comments (`/* */`, `<!-- -->`) are out of scope.
+- **Tuning:** `COMMENT_GUARD_MIN_COMMENTS` (default `2`) — minimum added comment lines before the hook speaks up. Set to `1` for strictest enforcement.
+- **Fail-safe:** missing `jq` or unexpected input exits silently; the hook can never disrupt an edit.
+
 ## Knowledge Compounding
 
 The plugin includes a `docs/solutions/` knowledge base and the `/ba:compound` command to populate it. When you solve a problem, run `/ba:compound` (or let it auto-trigger) to document the solution. The `learnings-researcher` agent surfaces relevant learnings during future brainstorm and plan sessions, so the same mistakes aren't repeated.

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,0 +1,18 @@
+{
+  "description": "Comment-style guard: after an Edit/Write/MultiEdit that adds code comments, re-assert the why-comments-only convention on the just-written diff.",
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}\"/scripts/comment-guard.sh",
+            "timeout": 10,
+            "statusMessage": "Checking comment style..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/scripts/comment-guard.sh
+++ b/scripts/comment-guard.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+#
+# comment-guard.sh — PostToolUse hook for Edit/Write/MultiEdit.
+#
+# Why this exists: a "why-comments only" rule lives in memory files and an
+# end-of-run reviewer, yet verbose/restating comments still get written. Memory
+# files lose salience deep in a long edit session, and a review nit at the end
+# of a slice is easy to defer. This hook re-asserts the rule at the moment a
+# comment is written, on the small diff that just landed — the only point where
+# the reminder is both salient and cheap to act on.
+#
+# It does the deterministic half (did this edit add full-line comments? which
+# ones?) and hands the judgment half (why-comment vs. restating) back to the
+# model by surfacing the exact lines. It never fires on edits that added no
+# comments, so the reminder stays meaningful instead of becoming background noise.
+#
+# Tuning: COMMENT_GUARD_MIN_COMMENTS (default 2) — minimum added comment lines
+# before the hook speaks up. Set to 1 for strictest enforcement.
+#
+# Fails safe: any missing dependency or unexpected input exits 0 (silent) so the
+# hook can never disrupt an edit.
+
+# No `set -e`: several pipeline steps return non-zero benignly; we handle flow
+# explicitly and prefer silence over disruption.
+set -u
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+input="$(cat)"
+[ -n "$input" ] || exit 0
+
+file_path="$(printf '%s' "$input" | jq -r '.tool_input.file_path // empty' 2>/dev/null)"
+[ -n "$file_path" ] || exit 0
+
+# Text this edit introduced: Write=content, Edit=new_string,
+# MultiEdit=every edit's new_string, plus the normalized file_text field.
+added="$(printf '%s' "$input" | jq -r '
+  [ .tool_input.content,
+    .tool_input.new_string,
+    .tool_input.file_text,
+    ( .tool_input.edits // [] | .[].new_string )
+  ] | map(select(. != null)) | join("\n")
+' 2>/dev/null)"
+[ -n "$added" ] || exit 0
+
+ext="${file_path##*.}"
+ext="$(printf '%s' "$ext" | tr '[:upper:]' '[:lower:]')"
+
+# Extension -> full-line comment prefix. Unlisted extensions (md, json, yaml,
+# txt, ...) are intentionally skipped: this guards code comments, not prose or
+# config. Block comments (/* */, <!-- -->) are out of scope for v1.
+case "$ext" in
+  js|jsx|ts|tsx|mjs|cjs|go|rs|java|c|cc|cpp|cxx|h|hpp|hh|cs|swift|kt|kts|scala|php|m|mm|dart) prefix='//' ;;
+  py|rb|sh|bash|zsh|pl|ex|exs|nim|r) prefix='#' ;;
+  lua|sql|hs|elm|adb|ads) prefix='--' ;;
+  el|clj|cljs|cljc|lisp|scm) prefix=';' ;;
+  *) exit 0 ;;
+esac
+
+min_comments="${COMMENT_GUARD_MIN_COMMENTS:-2}"
+
+# Collect full-line comments from the added text. A shebang is not narration.
+# Matching on the trimmed line start keeps comment markers inside strings/URLs
+# (e.g. "https://", "x = 1  # ...") from registering as comments.
+comment_lines="$(printf '%s\n' "$added" | awk -v pfx="$prefix" '
+  {
+    line = $0
+    sub(/^[ \t]+/, "", line)
+    if (line == "") next
+    if (line ~ /^#!/) next
+    if (substr(line, 1, length(pfx)) == pfx) print line
+  }
+')"
+
+count="$(printf '%s' "$comment_lines" | grep -c . 2>/dev/null || true)"
+[ -n "$count" ] || count=0
+[ "$count" -ge "$min_comments" ] 2>/dev/null || exit 0
+
+# Cap the quoted listing; report the rest as a count so a big rewrite stays readable.
+listing="$(printf '%s\n' "$comment_lines" | head -10 | sed 's/^/    /')"
+extra=""
+if [ "$count" -gt 10 ]; then
+  extra="$(printf '\n    … and %d more' "$((count - 10))")"
+fi
+
+msg="$(printf '%s' "Comment-style check (dev-workflow) — this edit to ${file_path} added ${count} comment line(s):
+
+${listing}${extra}
+
+Project convention: comments are why-comments only. Keep non-obvious rationale, workarounds, and invariant explanations; delete anything that merely restates what the code already says. Re-read the comment lines above now and remove the redundant ones before continuing.")"
+
+jq -n --arg ctx "$msg" '{
+  hookSpecificOutput: {
+    hookEventName: "PostToolUse",
+    additionalContext: $ctx
+  }
+}'
+exit 0


### PR DESCRIPTION
Enforce the why-comments-only convention at write time instead of
relying on memory-file salience or a deferrable /ba:review nit. After an
Edit/Write/MultiEdit that adds full-line comments to a code file, the
hook injects a system reminder listing those exact lines and re-asserts
the convention; it stays silent when no comments were added so the
reminder doesn't habituate into noise. Deterministic detection, model
judgment on the small fresh diff.

- hooks/hooks.json: PostToolUse matcher Edit|Write|MultiEdit
- scripts/comment-guard.sh: extension-aware full-line comment detection,
  COMMENT_GUARD_MIN_COMMENTS tuning (default 2), fail-safe exits
- docs: README Hooks section, CLAUDE.md Hooks section + convention
- bump plugin version 0.24.1 -> 0.25.0

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CWCHUGzbMG99xoi8dcW8uJ