### PR TITLE
feat(plan): add requirement reconciliation ledger

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-workflow",
-  "version": "0.35.0",
+  "version": "0.36.0",
   "description": "Research, brainstorm, plan, execute, review, compound, and propose commands with triage, convention compliance, and knowledge compounding",
   "author": {
     "name": "Bruno Azevedo"

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Transforms feature descriptions into implementation plans with exact file paths 
 - **Conditional external research** — risk-based: security/payments always research externally; known patterns skip it
 - **Three detail levels** — MINIMAL (simple bugs), STANDARD (most features), COMPREHENSIVE (major features with phased implementation and phase gates)
 - **SpecFlow analysis** — agent maps all user flows, identifies edge cases and gaps before plan is finalized
-- **Requirement reconciliation ledger** — every explicit origin requirement is reconciled to an AC or a provenance-tagged exclusion and printed before write; a plan-introduced exclusion, thin origin, or unresolved origin joins the pre-write gate instead of silently narrowing scope
+- **Requirement reconciliation ledger** — every explicit origin requirement is reconciled to an AC or a provenance-tagged exclusion and printed before write; a plan-introduced exclusion, a material ambiguity, or an unresolved origin joins the pre-write gate instead of being resolved silently
 - **"What We're NOT Doing"** — every plan includes explicit scope boundaries
 
 Plans are saved to `docs/plans/YYYY-MM-DD-<type>-<name>-plan.md` (default) or `.html`.

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Transforms feature descriptions into implementation plans with exact file paths 
 - **Conditional external research** — risk-based: security/payments always research externally; known patterns skip it
 - **Three detail levels** — MINIMAL (simple bugs), STANDARD (most features), COMPREHENSIVE (major features with phased implementation and phase gates)
 - **SpecFlow analysis** — agent maps all user flows, identifies edge cases and gaps before plan is finalized
+- **Requirement reconciliation ledger** — every explicit origin requirement is reconciled to an AC or a provenance-tagged exclusion and printed before write; a plan-introduced exclusion, thin origin, or unresolved origin joins the pre-write gate instead of silently narrowing scope
 - **"What We're NOT Doing"** — every plan includes explicit scope boundaries
 
 Plans are saved to `docs/plans/YYYY-MM-DD-<type>-<name>-plan.md` (default) or `.html`.

--- a/commands/ba/plan.md
+++ b/commands/ba/plan.md
@@ -213,7 +213,7 @@ After structuring the plan, run the spec-flow analyzer to validate completeness:
 
 **After receiving results:**
 - Review identified gaps and edge cases
-- For each finding, check whether it proposes **narrowing or dropping** a requirement rather than adding coverage. A finding at **critical/important** tier that does so is **not** silently folded — hold it under a `Parked-for-gate:` list in your running context (never written into the plan document) until Step 5 reads it and decides. Record each entry in a minimal structured shape so Step 5 can match it against the ledger by lookup rather than free-text judgment: `Parked-for-gate: <finding text> — targets: "<origin requirement text>"`.
+- For each finding, check whether it proposes **narrowing or dropping** a requirement rather than adding coverage. A critical/important finding that does so is **not** silently folded — park it (in your running context, never in the plan document) and carry it to Step 5's decision round, noting which origin requirement it targets.
 - Incorporate all other critical and important findings into acceptance criteria
 - Add missing error handling or validation requirements to the plan
 - Note any flow permutations that need addressing
@@ -496,11 +496,13 @@ Purely visual or manual checks belong in `Test scenarios:`, never in `Verify:`. 
 ## Step 4.6: Requirement Reconciliation
 
 After drafting the plan (Step 4) and before the pre-write decision gate (Step 5), reconcile the
-plan's Acceptance Criteria against the origin's explicit requirements. This step runs at **every
-detail level** (MINIMAL, STANDARD, COMPREHENSIVE) and for **every origin type** (brainstorm,
-ticket text already present in context, or a refined bare prompt) — it is the anti-silent-drop
-core of `/ba:plan`, and its cost is low enough to justify running unconditionally; the failure it
-guards against can bite even a MINIMAL plan.
+plan's Acceptance Criteria against the origin's explicit requirements. Runs at **every detail
+level** (MINIMAL, STANDARD, COMPREHENSIVE) and for **every origin type** (brainstorm, ticket text
+already present in context, or a refined bare prompt).
+
+The job is traceability in both directions: every origin requirement should reach an AC or an
+owned exclusion, and every AC should trace back to something the origin asked for. Requiring that
+trace keeps a plan from quietly growing past its origin as much as from quietly shrinking below it.
 
 **1. Enumerate explicit requirements.**
 
@@ -508,51 +510,39 @@ Scan the origin — source-agnostic: the brainstorm document, ticket text alread
 context, or the refined prompt; never a Linear/tracker API call — for *explicit* requirements. An
 explicit requirement is an imperative, user-observable demand: a "must/should" statement, a
 bulleted requirement or fix-direction, or an explicit brainstorm acceptance criterion. Exclude
-background, rationale, implementation suggestions, and examples — those inform the plan but are
-not requirements to reconcile.
+background, rationale, implementation suggestions, and examples.
 
-**`origin-unresolved` detection.** If the origin is a bare reference — a ticket ID or URL, "see
-the ticket" — whose body is not actually present in context, do not enumerate an empty list and
-call it clean. Mark the reconciliation `origin-unresolved` instead; this is a gate condition (Step
-5), never a clean pass produced from absent text.
+**`origin-unresolved`.** If the origin is a bare reference — a ticket ID or URL, "see the ticket" —
+whose body is not actually present in context, do not enumerate an empty list and call it clean.
+Mark the reconciliation `origin-unresolved`; that is a gate condition (Step 5), never a clean pass
+produced from absent text.
 
 **2. Decompose compound and bidirectional requirements into sub-clauses.**
 
 A requirement with multiple independent clauses, or a bidirectional demand ("keep A and B
-**separate**" ⇒ "A must not leak into B" **and** "B must not leak into A"), is split into its
-sub-clauses before reconciliation, and each sub-clause is reconciled independently. A sub-clause
-satisfied while its sibling sub-clause is dropped does **not** let the parent requirement
-reconcile as `→ AC<n>` — the dropped sub-clause gets its own disposition, evaluated on its own
-merits. Without this, a per-statement (non-decomposed) check waves through a requirement that is
-only half-honored.
+**separate**" ⇒ "A must not leak into B" **and** "B must not leak into A"), splits into its
+sub-clauses, each reconciled independently. A sub-clause satisfied while its sibling is dropped
+does **not** let the parent requirement reconcile as `→ AC<n>`.
 
 **3. Reconcile each requirement (or sub-clause) to an AC or an exclusion.**
 
 Resolve each item to one of:
-- `→ AC<n>` (one or more) — the requirement is covered by a minted acceptance criterion.
-- `→ EXCLUDED: <reason>` — the requirement is not covered. Record **provenance**:
-  - `inherited` — the exclusion mirrors a scope boundary the origin (brainstorm) already approved.
-  - `plan-introduced` — the plan itself chose to drop or narrow a requirement the approved origin
-    did not already exclude.
+- `→ AC<n>` (one or more) — covered by a minted acceptance criterion. Test it: *could the plan ship
+  and pass all its ACs without addressing this requirement?* If yes, it is under-mapped.
+- `→ EXCLUDED: <reason>` — not covered. Record **provenance**:
+  - `inherited` — mirrors a scope boundary the origin already approved.
+  - `plan-introduced` — the plan itself dropped or narrowed something the approved origin did not
+    already exclude.
 
   Only a `plan-introduced` exclusion is a gate condition (Step 5). An `inherited` exclusion prints
   in the ledger but never trips the gate.
 
-**Falsifiability self-check**, applied per requirement/sub-clause: *"could the plan ship and pass
-all its ACs without addressing this requirement? If yes, it is under-mapped"* — mirroring the
-`Verify:` falsifiability rule above. This catches a requirement that superficially maps to an AC
-but isn't actually covered by it, including a compound requirement whose dropped sub-clause would
-otherwise hide behind its covered sibling.
+**4. Print the ledger on every path.**
 
-**4. Print the ledger, unconditionally, on every path.**
-
-Print the full reconciliation ledger regardless of detail level, origin type, or interactivity,
-and regardless of whether anything gates. **This is an invariant, not a courtesy: the ledger
-prints on every path; only the gate (Step 5) is conditional. A clean reconciliation and a skipped
-reconciliation must never produce identical output** — when nothing gates, the printed ledger
-itself is the observable proof this step ran.
-
-Ledger format (one line per requirement/sub-clause):
+The ledger prints regardless of detail level, origin type, or whether anything gates — a clean
+reconciliation and a skipped one must never produce identical output. Match its length to the
+plan: once nothing gates, a small plan may collapse to a single summary line (`7 requirements, all
+mapped`); a reconciliation carrying any exclusion or `origin-unresolved` always prints in full.
 
 ```
 - "<requirement text>" → AC<n>
@@ -561,92 +551,62 @@ Ledger format (one line per requirement/sub-clause):
 - origin-unresolved: <what's missing>
 ```
 
-**5. Resume dedupe.**
+The ledger is ephemeral — only an approved `plan-introduced` exclusion persists, via `## What We're
+NOT Doing`. A re-run recomputes it from the origin text, and dedupes against that section on the
+excluded requirement's identity rather than on its reason wording.
 
-The ledger itself is ephemeral: only an approved `plan-introduced` exclusion persists to disk (via
-`## What We're NOT Doing`); a resumed run recomputes the full ledger from the origin text each
-time, never from a stored prior result.
-
-On a resumed/re-run `/ba:plan` for an in-flight plan, re-enumerating requirements can re-surface
-an exclusion already recorded. Before appending an approved `plan-introduced` exclusion to `## What
-We're NOT Doing`, check whether that requirement's exclusion is already present there. Dedupe on
-**the excluded requirement's identity** (which requirement is being excluded) — not the free-text
-reason string, since two runs may word the same exclusion differently and an exact-string match
-would append a near-duplicate.
-
-**Step 6 note:** this step is now the single owner of requirement/scope reconciliation for all
-origin types, not just brainstorm origins — Step 6 cross-references it instead of independently
-re-checking coverage.
+**Step 6 note:** this step owns requirement/scope reconciliation for all origin types, not just
+brainstorm origins — Step 6 cross-references it instead of independently re-checking coverage.
 
 ---
 
 ## Step 5: Pre-Write Decision Gate
 
-**MANDATORY.** Run before writing the plan to disk. This is a single **batched pre-write decision
-round**: it merges the convention-compliance check with four scope/fidelity stop conditions
-surfaced by Step 4.6's reconciliation ledger and Step 3's parked findings, so the user is never
-stopped twice for the same plan.
+**MANDATORY.** Run before writing the plan to disk. A single **batched decision round** covering
+the convention-compliance check plus the scope/fidelity stop conditions surfaced by Step 4.6's
+ledger and Step 3's parked findings, so the user is never stopped twice for the same plan.
 
-**1. Gather convention violations** (as before):
+**1. Gather convention violations:**
    - Dispatch the convention-checker agent:
      - Task dev-workflow:convention-checker("Validate this plan against project conventions: <summary of plan including file paths, naming, architecture decisions, test structure, new dependencies>")
    - Review the agent's findings. Also check each `Verify:` line in the plan: flag any that
      appears unmatchable (no grep-able symbol/path/command) or non-read-only (runs a command with
      side effects).
 
-**2. Gather the four requirement/scope stop conditions** from Step 4.6's ledger and Step 3's
-parked findings:
+**2. Gather the scope/fidelity stop conditions** from Step 4.6's ledger and Step 3's parked
+findings:
    - **(a)** Any `plan-introduced` exclusion in the ledger.
-   - **(b)** Any `Parked-for-gate:` spec-flow finding (critical/important tier, proposing to
-     narrow/drop a requirement) from Step 3 — scoped to findings **not already covered by an
-     origin-explicit requirement** in the ledger (a spec-flow-discovered gap the origin never
-     stated). Use each entry's recorded `targets:` field (see Step 3) — a recorded match, not a
-     free-text guess — to check this: when a parked finding's `targets:` names the *same*
-     origin-explicit requirement the ledger already flagged as (a), it is one decision, not two —
-     the batched round below asks **once**.
-   - **(c)** A **thin-origin divergence**: the reconciliation is thin-origin (the origin yielded
-     fewer than 2 explicit requirements, OR at least half the minted ACs are assistant-inferred
-     with no origin-traceable requirement) **and** (the detail level is STANDARD/COMPREHENSIVE,
-     **or** a strict majority — more than half, not merely at-least-half — of minted ACs are
-     assistant-inferred). An **assistant-inferred AC** is one with no `→ AC<n>` line pointing to it
-     anywhere in the Step 4.6 ledger — derive this by inverting the ledger, do not track it as
-     separate data. Requiring a *strict* majority on the second clause keeps it distinguishable from
-     the first clause's at-least-half test, so a MINIMAL plan sitting exactly at half (e.g. 2 of 4
-     ACs inferred — a normal split) does **not** trip the gate: a thin origin on a correctly-scoped
-     MINIMAL plan is suppressed — this is not a fuzzy judgment call.
+   - **(b)** Any parked spec-flow finding from Step 3 that proposes narrowing or dropping a
+     requirement. When it targets the same requirement already flagged by (a), it is one decision,
+     not two — ask once.
+   - **(c)** Any **material ambiguity**: an origin requirement that admits two readings which would
+     lead to materially different work, and that you resolved by picking one. Coverage is not the
+     only way to lose a requirement — one mapped to an AC under a silently-chosen reading is still
+     a scope call made on the user's behalf. Report the requirement, the reading you took, and the
+     alternative. Routine implementation choices are not ambiguities; do not report them.
    - **(d)** `origin-unresolved` from Step 4.6.
 
-**3. Evaluate both categories, then branch on interactivity.** The two categories are batched into
-one *presentation* round, but their resolution semantics differ (see the carve-out below).
-
-**4. Interactive session:**
+**3. Interactive session:**
    - If there are **no** convention violations and **none** of (a–d) apply: write with **no added
-     prompt** — the clean-pass case. A plan whose requirements all map cleanly, with nothing to
-     ask, must not add gate fatigue on the common path.
+     prompt**. A plan that reconciles cleanly with nothing to ask must not add gate fatigue.
    - Otherwise, present **one batched AskUserQuestion round** covering every violation and every
-     (a–d) condition that applies (co-fired (a)/(b) pairs collapsed to one question, per above).
-     For each:
+     applicable (a–d) condition:
      - **Convention violation** — options: Update plan to comply / Add justification for override
        / Flag as known debt.
-     - **(a)/(b)/(c)/(d) condition** — options: Accept and continue (the exclusion/divergence
-       stands, record it) / Revise the plan to cover it / Pause and let me decide.
-   - **MUST resolve all convention violations** before writing — unconditional, in every mode (see
-     the carve-out below). The (a–d) conditions may resolve to "accept."
+     - **(a)–(d) condition** — options: Accept and continue (it stands, record it) / Revise the
+       plan to cover it / Pause and let me decide.
+   - **MUST resolve all convention violations** before writing. The (a–d) conditions may resolve to
+     "accept."
 
-**5. Non-interactive session (Caution-1 carve-out — load-bearing):**
-   - **Evaluate convention violations first, independently of (a–d), and hard-stop** if any exist —
-     a non-interactive session **never auto-proceeds past a convention violation**, in every mode,
-     with no exception. This preserves the pre-existing "MUST resolve all violations before
-     writing" semantics unchanged. **Hard-stop means**: do not write the plan; print a
-     `convention-violation — hard-stop, non-interactive, plan not written` trace line naming each
-     unresolved violation, and end the run — never hang waiting on an AskUserQuestion that has no
-     answerer.
-   - **Only once no convention violations remain**, evaluate (a–d): print the ledger plus a
-     `gate not presented — non-interactive` trace line, and **proceed** — never hang waiting for
-     input that can't arrive. A mixed round (some violations, some a–d conditions) still hard-stops on
-     the violations; the a–d fallback never lets a violation ride through alongside it.
+**4. When no interactive answerer is available:** never hang on a question nothing can answer.
+   Convention violations still hard-stop — do not write the plan, print
+   `convention-violation — hard-stop, plan not written` naming each unresolved violation, and end
+   the run. With no violations outstanding, print the ledger plus
+   `gate not presented — no interactive answerer` and proceed. Detecting this condition has no
+   defined mechanism yet; until it does, treat the interactive path as the default and this as the
+   fallback for when a prompt cannot be presented.
 
-**6. Append compliance summary** to the plan's end (as before):
+**5. Append compliance summary** to the plan's end (as before):
    ```markdown
    ## Convention Compliance
    - [x] [Convention A] — aligned

--- a/commands/ba/plan.md
+++ b/commands/ba/plan.md
@@ -213,7 +213,7 @@ After structuring the plan, run the spec-flow analyzer to validate completeness:
 
 **After receiving results:**
 - Review identified gaps and edge cases
-- For each finding, check whether it proposes **narrowing or dropping** a requirement rather than adding coverage. A finding at **critical/important** tier that does so is **not** silently folded — hold it under a `Parked-for-gate:` list in your running context (never written into the plan document) until Step 5 reads it and decides.
+- For each finding, check whether it proposes **narrowing or dropping** a requirement rather than adding coverage. A finding at **critical/important** tier that does so is **not** silently folded — hold it under a `Parked-for-gate:` list in your running context (never written into the plan document) until Step 5 reads it and decides. Record each entry in a minimal structured shape so Step 5 can match it against the ledger by lookup rather than free-text judgment: `Parked-for-gate: <finding text> — targets: "<origin requirement text>"`.
 - Incorporate all other critical and important findings into acceptance criteria
 - Add missing error handling or validation requirements to the plan
 - Note any flow permutations that need addressing
@@ -563,6 +563,10 @@ Ledger format (one line per requirement/sub-clause):
 
 **5. Resume dedupe.**
 
+The ledger itself is ephemeral: only an approved `plan-introduced` exclusion persists to disk (via
+`## What We're NOT Doing`); a resumed run recomputes the full ledger from the origin text each
+time, never from a stored prior result.
+
 On a resumed/re-run `/ba:plan` for an in-flight plan, re-enumerating requirements can re-surface
 an exclusion already recorded. Before appending an approved `plan-introduced` exclusion to `## What
 We're NOT Doing`, check whether that requirement's exclusion is already present there. Dedupe on
@@ -596,13 +600,20 @@ parked findings:
    - **(b)** Any `Parked-for-gate:` spec-flow finding (critical/important tier, proposing to
      narrow/drop a requirement) from Step 3 — scoped to findings **not already covered by an
      origin-explicit requirement** in the ledger (a spec-flow-discovered gap the origin never
-     stated). When a parked finding (b) targets the *same* origin-explicit requirement the ledger
-     already flagged as (a), it is one decision, not two — the batched round below asks **once**.
+     stated). Use each entry's recorded `targets:` field (see Step 3) — a recorded match, not a
+     free-text guess — to check this: when a parked finding's `targets:` names the *same*
+     origin-explicit requirement the ledger already flagged as (a), it is one decision, not two —
+     the batched round below asks **once**.
    - **(c)** A **thin-origin divergence**: the reconciliation is thin-origin (the origin yielded
      fewer than 2 explicit requirements, OR at least half the minted ACs are assistant-inferred
      with no origin-traceable requirement) **and** (the detail level is STANDARD/COMPREHENSIVE,
-     **or** ≥2 ACs are assistant-inferred). A thin origin on a correctly-scoped MINIMAL plan does
-     **not** meet this condition and is suppressed — this is not a fuzzy judgment call.
+     **or** a strict majority — more than half, not merely at-least-half — of minted ACs are
+     assistant-inferred). An **assistant-inferred AC** is one with no `→ AC<n>` line pointing to it
+     anywhere in the Step 4.6 ledger — derive this by inverting the ledger, do not track it as
+     separate data. Requiring a *strict* majority on the second clause keeps it distinguishable from
+     the first clause's at-least-half test, so a MINIMAL plan sitting exactly at half (e.g. 2 of 4
+     ACs inferred — a normal split) does **not** trip the gate: a thin origin on a correctly-scoped
+     MINIMAL plan is suppressed — this is not a fuzzy judgment call.
    - **(d)** `origin-unresolved` from Step 4.6.
 
 **3. Evaluate both categories, then branch on interactivity.** The two categories are batched into
@@ -626,7 +637,10 @@ one *presentation* round, but their resolution semantics differ (see the carve-o
    - **Evaluate convention violations first, independently of (a–d), and hard-stop** if any exist —
      a non-interactive session **never auto-proceeds past a convention violation**, in every mode,
      with no exception. This preserves the pre-existing "MUST resolve all violations before
-     writing" semantics unchanged.
+     writing" semantics unchanged. **Hard-stop means**: do not write the plan; print a
+     `convention-violation — hard-stop, non-interactive, plan not written` trace line naming each
+     unresolved violation, and end the run — never hang waiting on an AskUserQuestion that has no
+     answerer.
    - **Only once no convention violations remain**, evaluate (a–d): print the ledger plus a
      `gate not presented — non-interactive` trace line, and **proceed** — never hang waiting for
      input that can't arrive. A mixed round (some violations, some a–d conditions) still hard-stops on

--- a/commands/ba/plan.md
+++ b/commands/ba/plan.md
@@ -213,7 +213,8 @@ After structuring the plan, run the spec-flow analyzer to validate completeness:
 
 **After receiving results:**
 - Review identified gaps and edge cases
-- Incorporate critical and important findings into acceptance criteria
+- For each finding, check whether it proposes **narrowing or dropping** a requirement rather than adding coverage. A finding at **critical/important** tier that does so is **not** silently folded — hold it under a `Parked-for-gate:` list in your running context (never written into the plan document) until Step 5 reads it and decides.
+- Incorporate all other critical and important findings into acceptance criteria
 - Add missing error handling or validation requirements to the plan
 - Note any flow permutations that need addressing
 
@@ -575,25 +576,63 @@ re-checking coverage.
 
 ---
 
-## Step 5: Convention-Compliance Check
+## Step 5: Pre-Write Decision Gate
 
-**MANDATORY.** Run before writing the plan to disk.
+**MANDATORY.** Run before writing the plan to disk. This is a single **batched pre-write decision
+round**: it merges the convention-compliance check with four scope/fidelity stop conditions
+surfaced by Step 4.6's reconciliation ledger and Step 3's parked findings, so the user is never
+stopped twice for the same plan.
 
-1. Dispatch the convention-checker agent:
-   - Task dev-workflow:convention-checker("Validate this plan against project conventions: <summary of plan including file paths, naming, architecture decisions, test structure, new dependencies>")
+**1. Gather convention violations** (as before):
+   - Dispatch the convention-checker agent:
+     - Task dev-workflow:convention-checker("Validate this plan against project conventions: <summary of plan including file paths, naming, architecture decisions, test structure, new dependencies>")
+   - Review the agent's findings. Also check each `Verify:` line in the plan: flag any that
+     appears unmatchable (no grep-able symbol/path/command) or non-read-only (runs a command with
+     side effects).
 
-2. Review the agent's findings. Also check each `Verify:` line in the plan: flag any that appears unmatchable (no grep-able symbol/path/command) or non-read-only (runs a command with side effects).
+**2. Gather the four requirement/scope stop conditions** from Step 4.6's ledger and Step 3's
+parked findings:
+   - **(a)** Any `plan-introduced` exclusion in the ledger.
+   - **(b)** Any `Parked-for-gate:` spec-flow finding (critical/important tier, proposing to
+     narrow/drop a requirement) from Step 3 — scoped to findings **not already covered by an
+     origin-explicit requirement** in the ledger (a spec-flow-discovered gap the origin never
+     stated). When a parked finding (b) targets the *same* origin-explicit requirement the ledger
+     already flagged as (a), it is one decision, not two — the batched round below asks **once**.
+   - **(c)** A **thin-origin divergence**: the reconciliation is thin-origin (the origin yielded
+     fewer than 2 explicit requirements, OR at least half the minted ACs are assistant-inferred
+     with no origin-traceable requirement) **and** (the detail level is STANDARD/COMPREHENSIVE,
+     **or** ≥2 ACs are assistant-inferred). A thin origin on a correctly-scoped MINIMAL plan does
+     **not** meet this condition and is suppressed — this is not a fuzzy judgment call.
+   - **(d)** `origin-unresolved` from Step 4.6.
 
-3. **For each VIOLATION**, use **AskUserQuestion** to present it:
-   - "Convention X says Y, but the plan does Z. How should we handle this?"
-   - Options:
-     1. **Update plan to comply** — Modify the plan to follow the convention
-     2. **Add justification for override** — Keep the plan as-is, document why
-     3. **Flag as known debt** — Acknowledge, plan to address later
+**3. Evaluate both categories, then branch on interactivity.** The two categories are batched into
+one *presentation* round, but their resolution semantics differ (see the carve-out below).
 
-4. **MUST resolve all violations** before writing the plan to disk.
+**4. Interactive session:**
+   - If there are **no** convention violations and **none** of (a–d) apply: write with **no added
+     prompt** — the clean-pass case. A plan whose requirements all map cleanly, with nothing to
+     ask, must not add gate fatigue on the common path.
+   - Otherwise, present **one batched AskUserQuestion round** covering every violation and every
+     (a–d) condition that applies (co-fired (a)/(b) pairs collapsed to one question, per above).
+     For each:
+     - **Convention violation** — options: Update plan to comply / Add justification for override
+       / Flag as known debt.
+     - **(a)/(b)/(c)/(d) condition** — options: Accept and continue (the exclusion/divergence
+       stands, record it) / Revise the plan to cover it / Pause and let me decide.
+   - **MUST resolve all convention violations** before writing — unconditional, in every mode (see
+     the carve-out below). The (a–d) conditions may resolve to "accept."
 
-5. Append compliance summary to the plan's end:
+**5. Non-interactive session (Caution-1 carve-out — load-bearing):**
+   - **Evaluate convention violations first, independently of (a–d), and hard-stop** if any exist —
+     a non-interactive session **never auto-proceeds past a convention violation**, in every mode,
+     with no exception. This preserves the pre-existing "MUST resolve all violations before
+     writing" semantics unchanged.
+   - **Only once no convention violations remain**, evaluate (a–d): print the ledger plus a
+     `gate not presented — non-interactive` trace line, and **proceed** — never hang waiting for
+     input that can't arrive. A mixed round (some violations, some a–d conditions) still hard-stops on
+     the violations; the a–d fallback never lets a violation ride through alongside it.
+
+**6. Append compliance summary** to the plan's end (as before):
    ```markdown
    ## Convention Compliance
    - [x] [Convention A] — aligned

--- a/commands/ba/plan.md
+++ b/commands/ba/plan.md
@@ -492,6 +492,89 @@ Purely visual or manual checks belong in `Test scenarios:`, never in `Verify:`. 
 
 ---
 
+## Step 4.6: Requirement Reconciliation
+
+After drafting the plan (Step 4) and before the pre-write decision gate (Step 5), reconcile the
+plan's Acceptance Criteria against the origin's explicit requirements. This step runs at **every
+detail level** (MINIMAL, STANDARD, COMPREHENSIVE) and for **every origin type** (brainstorm,
+ticket text already present in context, or a refined bare prompt) — it is the anti-silent-drop
+core of `/ba:plan`, and its cost is low enough to justify running unconditionally; the failure it
+guards against can bite even a MINIMAL plan.
+
+**1. Enumerate explicit requirements.**
+
+Scan the origin — source-agnostic: the brainstorm document, ticket text already present in
+context, or the refined prompt; never a Linear/tracker API call — for *explicit* requirements. An
+explicit requirement is an imperative, user-observable demand: a "must/should" statement, a
+bulleted requirement or fix-direction, or an explicit brainstorm acceptance criterion. Exclude
+background, rationale, implementation suggestions, and examples — those inform the plan but are
+not requirements to reconcile.
+
+**`origin-unresolved` detection.** If the origin is a bare reference — a ticket ID or URL, "see
+the ticket" — whose body is not actually present in context, do not enumerate an empty list and
+call it clean. Mark the reconciliation `origin-unresolved` instead; this is a gate condition (Step
+5), never a clean pass produced from absent text.
+
+**2. Decompose compound and bidirectional requirements into sub-clauses.**
+
+A requirement with multiple independent clauses, or a bidirectional demand ("keep A and B
+**separate**" ⇒ "A must not leak into B" **and** "B must not leak into A"), is split into its
+sub-clauses before reconciliation, and each sub-clause is reconciled independently. A sub-clause
+satisfied while its sibling sub-clause is dropped does **not** let the parent requirement
+reconcile as `→ AC<n>` — the dropped sub-clause gets its own disposition, evaluated on its own
+merits. Without this, a per-statement (non-decomposed) check waves through a requirement that is
+only half-honored.
+
+**3. Reconcile each requirement (or sub-clause) to an AC or an exclusion.**
+
+Resolve each item to one of:
+- `→ AC<n>` (one or more) — the requirement is covered by a minted acceptance criterion.
+- `→ EXCLUDED: <reason>` — the requirement is not covered. Record **provenance**:
+  - `inherited` — the exclusion mirrors a scope boundary the origin (brainstorm) already approved.
+  - `plan-introduced` — the plan itself chose to drop or narrow a requirement the approved origin
+    did not already exclude.
+
+  Only a `plan-introduced` exclusion is a gate condition (Step 5). An `inherited` exclusion prints
+  in the ledger but never trips the gate.
+
+**Falsifiability self-check**, applied per requirement/sub-clause: *"could the plan ship and pass
+all its ACs without addressing this requirement? If yes, it is under-mapped"* — mirroring the
+`Verify:` falsifiability rule above. This catches a requirement that superficially maps to an AC
+but isn't actually covered by it, including a compound requirement whose dropped sub-clause would
+otherwise hide behind its covered sibling.
+
+**4. Print the ledger, unconditionally, on every path.**
+
+Print the full reconciliation ledger regardless of detail level, origin type, or interactivity,
+and regardless of whether anything gates. **This is an invariant, not a courtesy: the ledger
+prints on every path; only the gate (Step 5) is conditional. A clean reconciliation and a skipped
+reconciliation must never produce identical output** — when nothing gates, the printed ledger
+itself is the observable proof this step ran.
+
+Ledger format (one line per requirement/sub-clause):
+
+```
+- "<requirement text>" → AC<n>
+- "<requirement text>" → EXCLUDED (inherited): <reason>
+- "<requirement text>" → EXCLUDED (plan-introduced): <reason>
+- origin-unresolved: <what's missing>
+```
+
+**5. Resume dedupe.**
+
+On a resumed/re-run `/ba:plan` for an in-flight plan, re-enumerating requirements can re-surface
+an exclusion already recorded. Before appending an approved `plan-introduced` exclusion to `## What
+We're NOT Doing`, check whether that requirement's exclusion is already present there. Dedupe on
+**the excluded requirement's identity** (which requirement is being excluded) — not the free-text
+reason string, since two runs may word the same exclusion differently and an exact-string match
+would append a near-duplicate.
+
+**Step 6 note:** this step is now the single owner of requirement/scope reconciliation for all
+origin types, not just brainstorm origins — Step 6 cross-references it instead of independently
+re-checking coverage.
+
+---
+
 ## Step 5: Convention-Compliance Check
 
 **MANDATORY.** Run before writing the plan to disk.
@@ -528,11 +611,10 @@ Before finalizing, re-read the brainstorm document and verify:
 
 - [ ] Every key decision from the brainstorm is reflected in the plan
 - [ ] The chosen approach matches what was decided in the brainstorm
-- [ ] Constraints and requirements are captured in acceptance criteria
+- [ ] Requirement and scope-boundary coverage — owned by Step 4.6's reconciliation ledger, not re-checked here
 - [ ] Open questions from the brainstorm are either resolved or flagged
 - [ ] The `origin:` frontmatter field points to the brainstorm file
 - [ ] The Sources section includes the brainstorm with carried-forward decisions
-- [ ] Scope boundaries from the brainstorm are in "What We're NOT Doing"
 
 If anything was dropped, add it back before writing.
 

--- a/docs/brainstorms/2026-07-24-plan-requirement-reconciliation-ledger-brainstorm.md
+++ b/docs/brainstorms/2026-07-24-plan-requirement-reconciliation-ledger-brainstorm.md
@@ -1,0 +1,166 @@
+---
+date: 2026-07-24
+topic: plan-requirement-reconciliation-ledger
+status: approved
+triage_level: full
+tags: [ba-plan, requirement-fidelity, acceptance-criteria, scope-guard, plan-gate]
+---
+
+# Requirement Reconciliation Ledger for `/ba:plan`
+
+## What We're Building
+
+A plan-time reconciliation step in `commands/ba/plan.md` that stops `/ba:plan` from silently
+dropping or narrowing an explicit origin requirement. After the plan body (and its `AC<n>`) is
+drafted, the command enumerates the origin's **explicit** requirements as a transient list,
+reconciles each to a disposition — either `→ AC<n>` (covered) or `→ EXCLUDED: <reason>` (a scope
+reduction, landing in the existing `## What We're NOT Doing`) — and prints the full mapping as an
+audit trail. Before the disk-write it **soft-gates**: it stops and asks the user (AskUserQuestion)
+when a requirement resolves to an exclusion, when a dispatched sub-agent flagged an open decision,
+or when the origin was too thin to trace (few/no explicit requirements, or ACs that are mostly the
+assistant's inference rather than origin-sourced). Clean requirement→AC mappings pass with no added
+friction.
+
+It is for the plan author (the assistant) and the human reviewing the plan — it closes the trust
+boundary "I trusted the Linear→plan translation was accurate" that the grounding case broke.
+
+## Why This Approach
+
+**The grounding failure was mis-located by the original handoff.** Full investigation (tiger
+!88267 / TATO-2943, transcript-verified) showed the requirement — "keep `notes` and `edit_reason`
+separate" — was explicit and path-owner-sourced, that **two** sub-agents (spec-flow-analyzer,
+convention-checker) flagged the decision as needing sign-off, and that `/ba:plan` let the assistant
+resolve it silently inside the artifact (demoted to `## What We're NOT Doing`, reframed as
+already-satisfied). `/ba:execute` then faithfully built the reduced scope. So the defect is at
+**plan time**, not execute or review time — every downstream gate anchors on the plan and cannot
+catch a defect the plan itself sanctions.
+
+**Two structural gaps confirmed by research (`commands/ba/plan.md`, `commands/ba/review-plan.md`):**
+- **Gap A — no requirement→AC reconciliation.** ACs are minted fresh ("*not inherited from the
+  origin ticket*", `plan.md:254`); nothing checks that every stated requirement became an AC or an
+  explicit exclusion. A requirement can simply never reappear.
+- **Gap B — scope reductions and flagged decisions resolve silently.** `## What We're NOT Doing` is
+  authored with no surfacing step; Step 3's spec-flow findings are folded via "incorporate / add /
+  note" with **no gate** (`plan.md:214-218`). The only hard gate today is Step 5 (convention
+  compliance) — it does not gate on requirement coverage or scope reduction.
+
+**Why this shape.** The mechanism reuses the project's established *enumerate-everything, drop-
+nothing-silently* ethos (as in `/ba:review`'s selection ledger) but is deliberately named the
+**requirement reconciliation ledger** and is **not** a mirror site of the reviewer never-hide
+convention (which names exactly three sites — keep them untouched). It is confined to `plan.md`,
+the only command that sees the origin, and it steps around the locked AC/`Verify:`/`Test scenarios:`
+schema by *mapping* origin requirements to plan-minted ACs, never inheriting or renumbering them.
+
+**Rejected alternatives.** (1) *Minimal gate-only, no ledger* — surfaces exclusions but enumerates
+nothing, so a requirement never mentioned again still vanishes; rejected as not fixing Gap A.
+(2) *First-class Linear ingestion* — a real fetch/parse path; rejected as Linear-coupled and heavier
+than needed (source-agnostic capture works for any origin, matching issue #6's re-scoping).
+(3) *Delegate the backstop to `/ba:review-plan`* — it reads only the plan, never the origin
+(`review-plan.md:78-80, 615`), so it structurally cannot reconcile against requirements; that is
+issue #6's coverage-only territory and a separate, larger change.
+
+## Key Decisions
+
+- **Source-agnostic requirement capture.** Enumerate the *explicit* requirements already in context
+  — pasted/fetched ticket text, the brainstorm, or the refined prompt. "Explicit" = a stated
+  requirement / fix-direction / acceptance in the origin, not inferred desiderata. No Linear API
+  integration. Rationale: works for every origin; avoids tracker coupling.
+- **Show-all, stop-on-reductions (soft-gate).** Print the full ledger for auditability, but only
+  block-and-ask on (a) any requirement dispositioned as an exclusion, (b) any sub-agent finding
+  flagged as needing an explicit decision, and (c) a thin/low-fidelity origin (see next decision).
+  Clean 1:1 requirement→AC mappings pass silently. Rationale: catches the real failure (a
+  rationalized exclusion) without gate fatigue, since exclusions/flagged-decisions are rare relative
+  to clean coverage.
+- **Thin-origin / inferred-AC signal (third stop condition).** A thin ledger must not be a silent
+  no-op. When the origin yields few or no explicit requirements, or when most minted ACs trace to
+  the assistant's interpretation rather than the origin, surface it before writing — *"origin was
+  thin: N ACs inferred, M sourced; confirm this is the intended scope"* — and stop for the user's
+  sign-off. Rationale: a poor ticket is exactly where the Linear→plan translation is least
+  trustworthy (the grounding case's broken trust boundary); the coverage half (Gap A) is otherwise
+  near-vacuous on a lacking ticket — this turns that silence into an explicit interpretation check.
+  It does **not** invent requirements — it makes the *act of inferring* visible and consented to.
+- **Amend Step 3 (and Step 5) finding-handling.** A sub-agent finding explicitly flagged as "needs
+  an explicit decision" / "under-specified — author must be explicit" must route into the gate's
+  stop-and-ask set rather than being silently folded via "incorporate / add / note". This is the
+  direct cause in the grounding case and the core of Gap B.
+- **Transient ledger, not a persisted plan section.** The requirement→AC mapping is scaffolding used
+  to find the gaps, then discarded; approved exclusions live in the existing `## What We're NOT
+  Doing` with their (now user-approved) reasons. Rationale (Simplicity First / YAGNI + the locked
+  read-only-plan model): avoids a new template section, a `references/plan-sections.md` contract
+  change, and any new plan state. The bug-relevant decisions (exclusions-with-reasons) remain
+  durable regardless. *(This is an internal-mechanism choice, not a scope reduction of the request —
+  both gaps are fully fixed either way.)*
+- **Generalizes the brainstorm-only cross-check.** Today's Step 6 requirement-capture line
+  (`plan.md:531`) runs only for brainstorm origins and is prose-only; the new step supersedes it
+  with a source-agnostic reconciliation.
+- **Named distinctly; not a never-hide mirror site.** Per convention-check Flag 1 — keep the
+  concept, avoid the "never-hide ledger" label, and do not touch the three reviewer mirror sites.
+- Design-it-twice did not fire: this modifies an existing command's flow (no new module/interface
+  boundary), so no `## Locked Design` section.
+
+## Scope Boundaries
+
+- **No changes to `commands/ba/execute.md` or `commands/ba/review.md`.** The execute/verify model
+  and its locked AC exclusion are correct and stay untouched.
+- **No Linear/tracker API ingestion path** — source-agnostic capture only.
+- **No new persisted `## Requirement Ledger` plan section** — transient; reuses `## What We're NOT
+  Doing`.
+- **`/ba:review-plan` is not given the origin** and gets no requirement backstop here — that is
+  issue #6 (review-completeness), a separate effort.
+- **The locked AC / `Verify:` / `Test scenarios:` schema is not reopened.**
+- **No auto-generation of ACs from requirements** — the assistant still authors ACs; the ledger only
+  checks coverage and surfaces reductions.
+- **No CE-style mandatory behavior-pinning-test rule** — the deepest real backstop observed (a test
+  that fails if the requirement is violated) is noted as future work, not built here.
+
+## Acceptance Criteria
+
+- AC1: `/ba:plan` enumerates the origin's explicit requirements (source-agnostic) and reconciles
+  each to either an `AC<n>` or an explicit exclusion; no explicit requirement is silently absent
+  from the reconciliation.
+- AC2: The full reconciliation ledger (every requirement → AC or exclusion) is shown to the user
+  before the plan is written to disk.
+- AC3: The command STOPS and asks the user (AskUserQuestion) before the disk-write when a requirement
+  is dispositioned as an exclusion, OR when a dispatched sub-agent returned a finding flagged as
+  needing an explicit decision.
+- AC4: A plan whose requirements all map cleanly to ACs, with no exclusions and no flagged decisions,
+  is written without any added prompt (no gate fatigue on the common case).
+- AC5: The change is confined to `commands/ba/plan.md`; `execute.md`, `review.md`, and the locked AC
+  schema are unchanged, and no reviewer never-hide mirror site is modified.
+- AC6 (grounding regression): Replaying the tiger!88267 scenario, "keep `notes` and `edit_reason`
+  separate" is enumerated as a requirement and, being dispositioned as an exclusion, is surfaced to
+  the user before write — it cannot be silently demoted to `## What We're NOT Doing`.
+- AC7 (thin-origin): When the origin carries few/no explicit requirements, or the minted ACs are
+  mostly assistant-inferred rather than origin-sourced, `/ba:plan` surfaces that (a count of
+  inferred vs. sourced ACs) and stops for the user's sign-off before writing — rather than
+  proceeding silently on a low-fidelity translation.
+
+## Open Questions
+
+None. (Resolved this session: ledger source → source-agnostic capture; gate strictness →
+show-all/stop-on-reductions; persist vs. transient → transient; review-plan involvement → out of
+scope; poor/lacking ticket → added the thin-origin / inferred-AC third stop condition.)
+
+## Convention Compliance
+
+Checked by `convention-checker` — **0 hard violations**. Three plan-time flags recorded (not
+brainstorm defects):
+- **Flag 1 (MEDIUM, incorporated):** do not reuse the "never-hide ledger" label (a proper-noun
+  convention with exactly three mirror sites — `README.md`, `review.md` Step 2, `review-plan.md`
+  Step 2). Named the mechanism "requirement reconciliation ledger" and stated it is not a mirror
+  site; the three existing sites stay untouched.
+- **Flag 2 (LOW–MEDIUM, for the plan):** a user-facing `/ba:plan` behavior change likely triggers
+  the README-sync obligation — the plan should include a unit to touch the README `/ba:plan`
+  description (and the CLAUDE.md convention bullet if the gate is elevated to a convention), or a
+  justified skip.
+- **Flag 3 (LOW, for the plan):** the shipping unit must bump `version` in
+  `.claude-plugin/plugin.json` (currently `0.35.0`) — it is the auto-update cache key.
+
+Aligned on all sharp landmines: planning-never-writes-code, the U-ID/stack-base citation grid
+(untouched — `plan.md` stays grammar-only), the locked AC schema (mapping, not inheriting), and the
+mandatory pre-write convention gate (strengthened, not weakened).
+
+## Next Steps
+
+→ `/ba:plan` to create the implementation plan (confined to `commands/ba/plan.md`; carry Flags 2–3
+as plan-time obligations).

--- a/docs/plans/2026-07-25-feat-plan-requirement-reconciliation-ledger-plan.md
+++ b/docs/plans/2026-07-25-feat-plan-requirement-reconciliation-ledger-plan.md
@@ -1,0 +1,305 @@
+---
+title: Add requirement reconciliation ledger to /ba:plan
+type: feat
+plan_schema: 2
+status: active
+date: 2026-07-25
+origin: docs/brainstorms/2026-07-24-plan-requirement-reconciliation-ledger-brainstorm.md
+detail_level: standard
+tags: [ba-plan, requirement-fidelity, acceptance-criteria, scope-guard, plan-gate]
+---
+
+# Add requirement reconciliation ledger to /ba:plan Implementation Plan
+
+## Overview
+
+Add a requirement-reconciliation step to `commands/ba/plan.md` so `/ba:plan` cannot silently drop
+or narrow an explicit origin requirement. After the plan body and its `AC<n>` are drafted, the
+command enumerates the origin's explicit requirements (source-agnostic), reconciles each to an
+`AC<n>` or an explicit exclusion, prints the full ledger on every path, and — folded into the
+existing mandatory pre-write gate — stops to ask the user only on scope-reducing or low-fidelity
+outcomes. Confined to `plan.md` plus two doc-sync edits. See brainstorm:
+`docs/brainstorms/2026-07-24-plan-requirement-reconciliation-ledger-brainstorm.md`.
+
+## Current State
+
+- `commands/ba/plan.md:59-108` — Step 0 ingests a brainstorm origin richly (carry-forward at
+  `:81-89`, "the brainstorm is the origin document" `:91`) or refines a bare prompt; a Linear
+  ticket is **not** a recognized ingestion path (only outbound `issue create` in Step 7).
+- `plan.md:254` — AC minting: "*plan-owned, minted here, **not inherited from the origin ticket***"
+  — no reconciliation back to origin requirements exists.
+- `plan.md:214-218` — Step 3 spec-flow findings are folded via "incorporate / add / note" with
+  **no gate** (the direct Gap-B mechanism in the grounding case).
+- `plan.md:261-263, 308-309, 376-377` — `## What We're NOT Doing` is authored silently; nothing
+  surfaces exclusions to the user.
+- `plan.md:495-519` — Step 5 convention-compliance is the **only** mandatory pre-write gate
+  ("MUST resolve all violations before writing", `:511`); it gates on convention, not requirement
+  coverage.
+- `plan.md:523-537` — Step 6 brainstorm cross-check is brainstorm-only and prose-only; lines
+  `:531` ("Constraints and requirements are captured in acceptance criteria") and `:535`
+  ("Scope boundaries … in What We're NOT Doing") overlap the new step.
+- `plan.md:570-595` — Step 7 runs `/ba:review-plan --auto` (reads only the plan; never the origin).
+- `.claude-plugin/plugin.json:3` — `"version": "0.35.0"`.
+- `docs/solutions/` — does not exist (no prior learnings).
+
+## Acceptance Criteria
+
+- AC1: `/ba:plan` enumerates the origin's explicit requirements (source-agnostic — from ticket text
+  in context, the brainstorm, or the refined prompt; no Linear API) and reconciles each to either
+  an `AC<n>` or an explicit exclusion; no explicit requirement is silently absent from the
+  reconciliation.
+- AC2: The full reconciliation ledger **prints on every reachable `/ba:plan` path** — all detail
+  levels, all origin types, interactive or not. A clean reconciliation and a skipped reconciliation
+  are never byte-identical output.
+- AC3: A single batched pre-write decision round stops and asks the user (AskUserQuestion) on any of:
+  (a) a **plan-introduced** exclusion, (b) a Step 3 spec-flow finding at critical/important tier that
+  proposes narrowing or dropping a requirement, (c) a thin-origin divergence, (d) `origin-unresolved`.
+  These are batched with Step 5's convention violations into one round — not serial stops.
+- AC4: A plan whose requirements all map cleanly to ACs, with none of the AC3 conditions present, is
+  written with no added prompt (no gate fatigue on the common case).
+- AC5: An inherited, already-user-approved brainstorm scope boundary is **printed** in the ledger but
+  does **not** trip the gate (only plan-introduced exclusions do).
+- AC6: When the origin is a bare reference (ticket ID/URL) whose body is not in context, `/ba:plan`
+  emits `origin-unresolved` and gates — it never emits a clean-looking empty ledger from absent text.
+- AC7: The thin-origin condition fires only on a fidelity↔ambition mismatch — not on a legitimately
+  small MINIMAL task with a thin origin. "Thin origin" has an **operational definition** (not a
+  fuzzy judgment): the origin yields **fewer than 2 explicit requirements**, OR **at least half the
+  minted ACs are assistant-inferred** (no origin-traceable requirement). The condition fires only
+  when that thin-origin test is true **and** (detail level is STANDARD/COMPREHENSIVE **or** ≥2
+  inferred ACs); it is suppressed on a MINIMAL plan whose small scope matches the thin origin.
+- AC8: In a non-interactive session the gate prints the ledger plus a "gate not presented —
+  non-interactive" trace and proceeds for the **new** decision conditions; it never hangs and never
+  silently drops. Convention-checker violations retain their unconditional resolve-before-write
+  semantics in every mode (they are never carried past on the non-interactive path).
+- AC9 (grounding regression): Replaying the tiger!88267 scenario, "keep `notes` and `edit_reason`
+  separate" is enumerated as a requirement and, dispositioned as a plan-introduced exclusion, is
+  surfaced to the user before write — it cannot be silently demoted to `## What We're NOT Doing`.
+- AC11 (partial coverage): A compound or bidirectional requirement is decomposed into
+  independently-reconciled sub-clauses. A requirement satisfied in one clause but dropped/narrowed
+  in another does **not** reconcile as fully covered (`→ AC<n>`) — the dropped sub-clause surfaces
+  as its own disposition (an exclusion, which then gates). This closes the sharper variant of the
+  grounding failure: tiger!88267 was a *bidirectional* requirement ("keep separate") met one way
+  and dropped the other, which a per-requirement (non-decomposed) check would wave through.
+- AC10: The change is confined to `commands/ba/plan.md`, `README.md`, and
+  `.claude-plugin/plugin.json`. `execute.md`, `review.md`, all agent files, the locked AC/`Verify:`
+  schema, and `references/plan-sections.md` are unchanged; no reviewer "selection ledger" mirror
+  site is modified; no new plan section is added.
+
+## What We're NOT Doing
+
+- No changes to `commands/ba/execute.md` or `commands/ba/review.md`.
+- No Linear/tracker API ingestion path — source-agnostic capture only.
+- No persisted `## Requirement Ledger` plan section; the ledger is transient (printed), and
+  `references/plan-sections.md` / the HTML header contract are untouched. Approved exclusions live
+  in the existing `## What We're NOT Doing`. *(User decision this session: transient over persisted.)*
+- No edits to `spec-flow-analyzer` / `convention-checker` agent output contracts — condition (b)
+  maps to spec-flow's existing critical/important tiers rather than a new machine flag.
+- `/ba:review-plan` is not given the origin and gets no requirement backstop here (that is issue #6,
+  separate).
+- The locked AC / `Verify:` / `Test scenarios:` schema is not reopened; ACs are still authored, not
+  auto-generated from requirements — the ledger only checks coverage and surfaces reductions.
+- No CE-style mandatory behavior-pinning-test rule (noted as future work in the brainstorm).
+
+## Proposed Solution
+
+A new **Requirement Reconciliation** step (Step 4.6, after Step 4 draft/AC-minting) computes a
+transient ledger: it enumerates the origin's explicit requirements, maps each to `→ AC<n>` or
+`→ EXCLUDED: <reason>` (recording provenance), and prints it unconditionally. The existing mandatory
+Step 5 gate is widened into a single batched pre-write decision round that adds four
+scope/fidelity stop conditions alongside its convention violations. Step 3 is amended so a flagged
+spec-flow finding is parked for that round instead of being silently folded. Step 6's two
+requirement/scope lines are trimmed to cross-reference the ledger. README and `plugin.json` are
+synced. The mechanism is the project's enumerate-everything-drop-nothing ethos, but named the
+"requirement reconciliation ledger" and explicitly **not** a mirror site of the reviewer selection
+ledger.
+
+## Technical Considerations
+
+- **Falsifiability of enumeration** is the weak link (spec-flow C2): the guarantee only holds if
+  enumeration catches the buried requirement. Step 4.6 carries an explicit self-check — *"for each
+  origin requirement, could the plan ship and pass all its ACs without addressing it? If yes, it is
+  under-mapped"* — mirroring the `Verify:` falsifiability rule at `plan.md:491`.
+- **Gate fatigue** is controlled by three design choices: provenance (AC5), divergence-gated
+  thin-origin (AC7), and batching into one round (AC3).
+- **The Caution-1 carve-out** (convention-checker gate) is a correctness constraint, not a
+  preference — see U2.
+
+## System-Wide Impact
+
+- **Interaction graph**: Step 4.6 consumes the drafted ACs + `## What We're NOT Doing` + parked
+  Step 3 findings; feeds the merged Step 5 gate; the gate precedes the Step 7 disk-write and the
+  `/ba:review-plan --auto` pass. No new agent dispatch.
+- **Error propagation**: `origin-unresolved` and non-interactive are explicit branches (AC6, AC8);
+  neither silently drops. Convention violations keep their hard pre-write semantics.
+- **State lifecycle**: ledger is transient (no persisted state); on a `/ba:plan` resume the step
+  re-enumerates and must dedupe against the existing `## What We're NOT Doing` rather than
+  blind-appending (spec-flow I5).
+
+## Implementation Approach
+
+**File**: `commands/ba/plan.md`
+
+### U1 — Requirement Reconciliation step (enumerate → reconcile → print) + Step 6 trim
+
+Add a new **Step 4.6 "Requirement Reconciliation"** after Step 4 (Draft the Plan), before Step 5.
+Decisions:
+- **Enumerate** the origin's *explicit* requirements as a transient list. Define "explicit"
+  tightly (spec-flow M3): an imperative, user-observable demand stated in the origin (a "must/
+  should", a bulleted requirement/fix-direction, an explicit brainstorm AC) — exclude background,
+  rationale, implementation suggestions, examples.
+- **Decompose compound/bidirectional requirements into sub-clauses** (review AC11): a requirement
+  with multiple independent clauses or a bidirectional demand (e.g. "keep A and B **separate**" ⇒
+  "A must not leak into B" **and** "B must not leak into A") is split into sub-clauses, each
+  reconciled independently. A sub-clause satisfied while its sibling is dropped does **not** let the
+  parent reconcile as `→ AC<n>` — the dropped sub-clause gets its own disposition. This is the fix
+  for the *partial-coverage* variant a per-statement check waves through.
+- **`origin-unresolved` detection** (spec-flow C2): if the origin is a bare reference (ticket
+  ID/URL, "see the ticket") whose body is **not** in context, do not emit a clean empty ledger —
+  mark the reconciliation `origin-unresolved` (a gate condition, handled in U2).
+- **Reconcile** each requirement to `→ AC<n>` (one or more) or `→ EXCLUDED: <reason>`. Record
+  **provenance** on each exclusion: `inherited` (mirrors an already-approved brainstorm scope
+  boundary carried in per `plan.md:84`) vs `plan-introduced` (the plan chose to drop/narrow a
+  requirement the approved origin did not already exclude). Only `plan-introduced` is a gate
+  condition (U2 / AC5).
+- **Falsifiability self-check** per Technical Considerations, applied **per sub-clause** during
+  reconciliation (so a partially-covered compound requirement fails the check on its dropped clause).
+- **Print the full ledger unconditionally** on every reachable path (all detail levels, all origin
+  types, interactive or not). State this as an explicit invariant in the step text: *the ledger
+  prints on every path; only the gate is conditional; a clean pass and a skipped reconciliation
+  must not produce identical output* (the propose-5f observability lesson — see
+  `docs/plans/2026-07-22-fix-propose-5f-mandatory-trace-plan.md`).
+- **All detail levels** run U1 (spec-flow M1) — the anti-silent-drop core is cheap and the failure
+  can bite a MINIMAL plan.
+- **Resume dedupe** (spec-flow I5): approved exclusions are written to `## What We're NOT Doing`
+  only if not already present. Dedupe on the **excluded requirement's identity** (which requirement
+  is being excluded), **not** the free-text reason string — two runs may word the same exclusion
+  differently, and an exact-string check would append a near-duplicate.
+- **Trim Step 6** (`plan.md:531` and `:535`): replace those two independent checks with a
+  cross-reference to Step 4.6 (the ledger now owns requirement/scope reconciliation for *all*
+  origins, not just brainstorm). Leave Step 6's other items (decisions reflected, approach matches,
+  open questions, `origin:` frontmatter, Sources) intact.
+
+Test scenarios:
+- A ticket requirement that maps to an AC shows `R→AC<n>` in the printed ledger (Covers AC1)
+- A requirement the plan drops shows `EXCLUDED: <reason>` with `plan-introduced` provenance
+  (Covers AC1, AC9)
+- An inherited brainstorm scope boundary shows in the ledger tagged `inherited` (Covers AC5)
+- A bare ticket-ID origin with no body in context yields `origin-unresolved`, not an empty ledger
+  (Covers AC6)
+- The ledger prints on a fully-clean MINIMAL plan (nothing gated) — output is not identical to a
+  run where the step was skipped (Covers AC2)
+- A bidirectional requirement ("keep A and B separate") whose plan covers only one direction does
+  NOT reconcile as `→ AC<n>`; the uncovered sub-clause surfaces as its own disposition
+  (Covers AC11)
+- Re-running `/ba:plan` on an in-flight plan does not duplicate `## What We're NOT Doing` entries,
+  matching on excluded-requirement identity not reason text (Covers AC1)
+
+Verify: `grep -q 'Requirement Reconciliation' commands/ba/plan.md && grep -q 'origin-unresolved' commands/ba/plan.md && grep -q 'plan-introduced' commands/ba/plan.md && grep -q 'inherited' commands/ba/plan.md && grep -q 'sub-clause' commands/ba/plan.md && ! grep -q 'Constraints and requirements are captured in acceptance criteria' commands/ba/plan.md`
+
+### U2 — Merged batched pre-write decision gate + Step 3 parking + non-interactive fallback
+
+Widen the existing MANDATORY Step 5 convention gate into a **single batched pre-write decision
+round**. Decisions:
+- **Stop-and-ask conditions** (new, batched with Step 5's convention violations into one
+  AskUserQuestion round, not serial stops): (a) a `plan-introduced` exclusion; (b) a Step 3
+  spec-flow finding at **critical/important** tier that proposes narrowing/dropping a requirement
+  (map to existing tiers — no agent-contract change); (c) **thin-origin divergence** per the
+  operational definition in AC7; (d) `origin-unresolved`.
+- **De-dupe (a) and (b)** (review — simplification): (a) and (b) can co-fire for the *same*
+  origin-explicit requirement (the ledger already surfaces it as a `plan-introduced` exclusion).
+  Scope (b) to spec-flow findings **not already covered by an origin-explicit requirement** (a
+  spec-flow-discovered gap the origin never stated); when they do co-fire on one requirement, the
+  batched round asks **once**, not twice.
+- **Clean pass** (none of a–d, no convention violations) writes with no added prompt (AC4).
+- **Caution-1 carve-out (load-bearing):** the non-interactive proceed-fallback applies **only** to
+  the new decision conditions (a–d). Convention-checker VIOLATIONS keep their pre-existing
+  unconditional "MUST resolve all violations before writing" semantics (`plan.md:511`) in **every**
+  mode. The gate text must carry the literal canonical marker phrase — *"never auto-proceeds past a
+  convention violation"* — so the carve-out is greppable by U2's `Verify:` and a regression that
+  drops it is falsifiable (review — test-coverage, conf 100).
+- **Non-interactive check order** (review AC8, was suppressed but folded in for airtightness):
+  evaluate convention violations **first** and hard-stop if any exist, independent of (a–d); only
+  then evaluate (a–d) for the trace-and-proceed path — so a mixed headless round can never leak a
+  violation past.
+- **Non-interactive fallback** (spec-flow M2): in a non-interactive session, print the ledger plus a
+  `gate not presented — non-interactive` trace and proceed for conditions (a–d); never hang. (Mirror
+  the trace shape in `docs/plans/2026-07-22-fix-propose-5f-mandatory-trace-plan.md`.)
+- **Amend Step 3** (`plan.md:214-218`): a spec-flow finding flagged (critical/important) as
+  proposing to narrow/drop a requirement is **parked** and routed to this gate instead of being
+  silently folded via "incorporate/add/note". **Carrier decision (pinned now, review — not deferred
+  to execution):** the parked finding is held in the assistant's running context under a named
+  heading — literally a `Parked-for-gate:` list — from Step 3 until the gate reads it; it is
+  **never** written into the plan doc. The `Parked-for-gate:` token is the distinctive string U2's
+  `Verify:` greps at both ends (producer in Step 3, consumer in the gate) so the wire can't dangle.
+
+Test scenarios:
+- A plan-introduced exclusion triggers one AskUserQuestion in the merged round (Covers AC3, AC9)
+- A convention violation and a plan-introduced exclusion surface in the **same** batched round, not
+  two serial stops (Covers AC3)
+- A thin origin on a MINIMAL, correctly-scoped task does **not** trigger the gate (Covers AC7)
+- A thin origin on a COMPREHENSIVE plan (or with several inferred ACs) triggers the thin-origin ask
+  (Covers AC7)
+- Non-interactive run past a plan-introduced exclusion prints the trace and proceeds; a convention
+  violation in the same run still blocks the write (Covers AC8)
+- A plan whose ledger has no exclusions, no origin-unresolved, no thin-origin divergence, and no
+  critical Step 3 finding writes with **no** AskUserQuestion round (Covers AC4)
+- A critical Step 3 spec-flow finding that proposes dropping a requirement reaches the gate rather
+  than being folded silently (Covers AC3)
+
+Verify: `grep -q 'plan-introduced' commands/ba/plan.md && grep -q 'gate not presented — non-interactive' commands/ba/plan.md && grep -q 'Parked-for-gate' commands/ba/plan.md && grep -q 'auto-proceeds past a convention' commands/ba/plan.md`
+
+### U3 — Doc sync (README + version bump)
+
+**Files**: `README.md`, `.claude-plugin/plugin.json`. Decisions:
+- Update the `/ba:plan` description in `README.md` with a substantive one-line mention of the
+  requirement reconciliation ledger / pre-write scope-reduction gate (not just a version string).
+  Edit only the `/ba:plan` block — do **not** touch the review/review-plan selection-ledger bullets
+  (avoids the three-site never-hide sync obligation).
+- Bump `.claude-plugin/plugin.json` `version` `0.35.0 → 0.36.0` (minor feature; the auto-update
+  cache key).
+
+Test scenarios:
+- `README.md` `/ba:plan` entry mentions the reconciliation ledger behavior (Covers AC10)
+- `plugin.json` reads `0.36.0` (Covers AC10)
+- The review/review-plan selection-ledger README bullets are unchanged
+
+Verify: `grep -q '"version": "0.36.0"' .claude-plugin/plugin.json && grep -qiE 'reconcil' README.md`
+
+## Dependencies & Risks
+
+- **Risk — enumeration misses a buried requirement** (the failure this fixes): mitigated by the
+  tight "explicit" definition + the falsifiability self-check (U1), but not eliminated; it degrades
+  gracefully (a missed requirement is no worse than today).
+- **Risk — merged gate weakens the convention check**: mitigated by the load-bearing Caution-1
+  carve-out (U2 / AC8). This is the item to review most carefully at execution.
+- **Risk — gate fatigue**: mitigated by provenance (AC5), divergence-gating (AC7), and batching
+  (AC3).
+- No external dependencies; no new agents; single-command scope keeps the U-ID and stack-base
+  citation grids untouched.
+
+## Sources & References
+
+- Origin brainstorm: `docs/brainstorms/2026-07-24-plan-requirement-reconciliation-ledger-brainstorm.md`
+  — carried forward: source-agnostic capture, show-all/stop-on-reductions, transient ledger, Step 6
+  supersession, thin-origin condition, scope boundaries, AC1–7.
+- Grounding case + root cause: tiger!88267 / TATO-2943 (requirement demoted at plan time, verified
+  via session transcripts).
+- Observability + non-interactive precedent: `docs/plans/2026-07-22-fix-propose-5f-mandatory-trace-plan.md`.
+- Locked AC/Verify schema (not reopened): `docs/brainstorms/2026-06-21-reconcile-acceptance-verification-schema-brainstorm.md`.
+- Related roadmap: issue #6 (review-completeness — separate, coverage-only).
+
+## Convention Compliance
+
+- [x] Planning-never-writes-code — ledger prints; exclusions land in `## What We're NOT Doing`;
+  no source write. Aligned.
+- [x] Convention-compliance mandatory before write — strengthened, not weakened; the Caution-1
+  carve-out (U2/AC8) keeps convention violations unconditionally blocking in every mode.
+- [x] Never-hide "selection ledger" proper noun — feature named "requirement reconciliation ledger",
+  distinct; no reviewer mirror site touched (U3 edits only the `/ba:plan` README block). Aligned.
+- [x] U-ID / stack-base citation grids — untouched (`plan.md` stays grammar-only; Step 6 is not a
+  convention owner). Aligned.
+- [x] Locked AC/`Verify:` schema + `references/plan-sections.md` — not reopened (transient ledger,
+  no new section). Aligned.
+- [x] README-sync + `plugin.json` bump (0.35.0 → 0.36.0) — U3. Aligned.
+- [x] `Verify:` minting — distinctive newly-introduced greps (falsifiable; avoid pre-existing terms
+  like bare "ledger"). Aligned.


### PR DESCRIPTION
**Risk:** low — prompt-spec-only change confined to `commands/ba/plan.md`, `README.md`, and a version bump; no sensitive paths, no breaking surface.

`/ba:plan` could silently drop or narrow an explicit origin requirement — no step ever reconciled the plan's minted ACs back against what the origin (ticket, brainstorm, or refined prompt) actually asked for. This adds a **Requirement Reconciliation** step (Step 4.6, source-agnostic) that enumerates the origin's explicit requirements, decomposes compound/bidirectional requirements into independently-checked sub-clauses, and maps each to an AC or a provenance-tagged exclusion (`inherited` vs. `plan-introduced`) — printing the full ledger unconditionally on every run, regardless of whether anything gates.

The existing convention-compliance check (Step 5) is widened into a single batched pre-write decision round that also stops on a plan-introduced exclusion, a thin-origin divergence, an unresolved origin reference, or a parked critical/important spec-flow finding — while convention violations keep their unconditional resolve-before-write semantics in every mode, including non-interactive runs (the Caution-1 carve-out).

**Testing:** no automated test suite exists for this prose command file; verified via the plan's own `Verify:` greps against `commands/ba/plan.md`, re-run after applying code-review fixes.

**Proof:** _pending — add tests / QA notes / screenshots before merge_
