### PR TITLE
feat: catch cross-file convention breaks via CI

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-workflow",
-  "version": "0.36.0",
+  "version": "0.37.0",
   "description": "Research, brainstorm, plan, execute, review, compound, and propose commands with triage, convention compliance, and knowledge compounding",
   "author": {
     "name": "Bruno Azevedo"

--- a/.github/workflows/invariants.yml
+++ b/.github/workflows/invariants.yml
@@ -1,0 +1,23 @@
+name: invariants
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  invariants:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Full history, not depth 2: on pull_request GitHub checks out an ephemeral merge
+          # commit whose first parent is the base branch tip, so HEAD~1 compares base->merge
+          # (the PR's cumulative diff). A shallow fetch at depth 2 can leave that parent
+          # grafted, silently truncating the comparison. Do not "optimize" this to depth 1.
+          fetch-depth: 0
+      - run: node scripts/selfcheck-invariants.mjs
+      - run: node scripts/check-invariants.mjs

--- a/.github/workflows/invariants.yml
+++ b/.github/workflows/invariants.yml
@@ -12,7 +12,7 @@ jobs:
   invariants:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           # Full history, not depth 2: on pull_request GitHub checks out an ephemeral merge
           # commit whose first parent is the base branch tip, so HEAD~1 compares base->merge

--- a/scripts/check-invariants.mjs
+++ b/scripts/check-invariants.mjs
@@ -6,6 +6,10 @@ import { execFileSync } from 'node:child_process';
 
 const VERDICT_CODE = { PASS: 0, FAIL: 1, UNKNOWN: 2 };
 
+function makeRecord(invariant, file, line, verdict, message) {
+  return { invariant, file, line, verdict, message };
+}
+
 function formatRecord(r) {
   const loc = r.line != null ? `${r.file}:${r.line}` : r.file;
   return `${r.invariant} — ${loc} — ${r.message}`;
@@ -76,8 +80,35 @@ function walkMarkdown(root, relDir) {
   return { files };
 }
 
-const SENTINEL_CORPUS_DIRS = ['commands', 'agents'];
+const PROMPT_SURFACE_DIRS = ['commands', 'agents'];
+const VERSION_BUMP_WATCHED_PREFIXES = [...PROMPT_SURFACE_DIRS, 'references'].map((d) => `${d}/`);
 const ALLOWED_AUTO_SCORE_KEYWORDS = new Set(['clean', 'weak', 'error']);
+
+// Reads the corpus once — both dir listing and file contents — so every check that needs the
+// same prompt-surface text shares one read and one error-reporting path, rather than each
+// sub-check re-reading files and trusting a sibling to have reported a read failure.
+function loadCorpus(opts, dirs, invariant) {
+  const files = [];
+  const errorRecords = [];
+  for (const dir of dirs) {
+    const res = walkMarkdown(opts.root, dir);
+    if (res.error) {
+      errorRecords.push(makeRecord(invariant, dir, null, 'UNKNOWN', `cannot list directory: ${res.error}`));
+      continue;
+    }
+    files.push(...res.files);
+  }
+  const entries = [];
+  for (const file of files) {
+    const lr = readLines(opts.root, file);
+    if (lr.error) {
+      errorRecords.push(makeRecord(invariant, file, null, 'UNKNOWN', `cannot read file: ${lr.error}`));
+      continue;
+    }
+    entries.push({ file, lines: lr.lines });
+  }
+  return { entries, errorRecords };
+}
 
 function fenceMatch(line) {
   const m = line.match(/^ {0,3}(`{3,}|~{3,})/);
@@ -85,10 +116,11 @@ function fenceMatch(line) {
   return { char: m[1][0], length: m[1].length };
 }
 
-// Only its own consumer (the heredoc sub-assertion) needs fence boundaries, so it lives here.
 // Tracks fence character and run length (not just "inside a fence") because the corpus has
 // four-backtick fences containing nested three-backtick fences — a length-blind scanner would
-// close on the inner fence and mis-split the region.
+// close on the inner fence and mis-split the region. A fence still open at EOF still yields a
+// region (start..EOF, terminated: false) so a heredoc opener inside it is recognized as "in a
+// fence" rather than misreported as bare prose — the fence's own UNKNOWN already covers it.
 function fencedRegions(lines) {
   const regions = [];
   const unterminated = [];
@@ -105,51 +137,23 @@ function fencedRegions(lines) {
       trimmed.length >= open.length &&
       [...trimmed].every((c) => c === open.char);
     if (isCloser) {
-      regions.push({ start: open.start, end: i });
+      regions.push({ start: open.start, end: i, terminated: true });
       open = null;
     }
   }
-  if (open) unterminated.push(open.start);
+  if (open) {
+    unterminated.push(open.start);
+    regions.push({ start: open.start, end: lines.length, terminated: false });
+  }
   return { regions, unterminated };
 }
 
-function loadCorpus(opts, dirs) {
-  const files = [];
-  const errorRecords = [];
-  for (const dir of dirs) {
-    const res = walkMarkdown(opts.root, dir);
-    if (res.error) {
-      errorRecords.push({
-        invariant: 'sentinels',
-        file: dir,
-        line: null,
-        verdict: 'UNKNOWN',
-        message: `cannot list directory: ${res.error}`,
-      });
-      continue;
-    }
-    files.push(...res.files);
-  }
-  return { files, errorRecords };
-}
-
-function autoScoreKeywordAgreement(opts, corpus) {
+function autoScoreKeywordAgreement(entries) {
   const records = [];
   const participants = [];
-  for (const file of corpus) {
-    const lr = readLines(opts.root, file);
-    if (lr.error) {
-      records.push({
-        invariant: 'sentinels',
-        file,
-        line: null,
-        verdict: 'UNKNOWN',
-        message: `cannot read file: ${lr.error}`,
-      });
-      continue;
-    }
+  for (const { file, lines } of entries) {
     const keywords = new Map();
-    lr.lines.forEach((line, idx) => {
+    lines.forEach((line, idx) => {
       const re = /\[AUTO-SCORE:\s*([a-z]+)/g;
       let m;
       while ((m = re.exec(line))) {
@@ -160,26 +164,22 @@ function autoScoreKeywordAgreement(opts, corpus) {
   }
 
   if (participants.length < 2) {
-    records.push({
-      invariant: 'sentinels',
-      file: SENTINEL_CORPUS_DIRS.join(', '),
-      line: null,
-      verdict: 'UNKNOWN',
-      message: `expected an emitter and a parser, found ${participants.length}`,
-    });
+    records.push(
+      makeRecord(
+        'sentinels',
+        PROMPT_SURFACE_DIRS.join(', '),
+        null,
+        'UNKNOWN',
+        `expected an emitter and a parser, found ${participants.length}`,
+      ),
+    );
     return { records, participantCount: participants.length };
   }
 
   for (const p of participants) {
     for (const [kw, line] of p.keywords) {
       if (!ALLOWED_AUTO_SCORE_KEYWORDS.has(kw)) {
-        records.push({
-          invariant: 'sentinels',
-          file: p.file,
-          line,
-          verdict: 'FAIL',
-          message: `[AUTO-SCORE: ${kw}] is outside {clean, weak, error}`,
-        });
+        records.push(makeRecord('sentinels', p.file, line, 'FAIL', `[AUTO-SCORE: ${kw}] is outside {clean, weak, error}`));
       }
     }
   }
@@ -189,13 +189,15 @@ function autoScoreKeywordAgreement(opts, corpus) {
       if (a === b) continue;
       for (const [kw, bLine] of b.keywords) {
         if (!a.keywords.has(kw)) {
-          records.push({
-            invariant: 'sentinels',
-            file: a.file,
-            line: bLine,
-            verdict: 'FAIL',
-            message: `keyword set differs from ${b.file}: missing '${kw}' (present at ${b.file}:${bLine})`,
-          });
+          records.push(
+            makeRecord(
+              'sentinels',
+              a.file,
+              bLine,
+              'FAIL',
+              `keyword set differs from ${b.file}: missing '${kw}' (present at ${b.file}:${bLine})`,
+            ),
+          );
         }
       }
     }
@@ -204,69 +206,62 @@ function autoScoreKeywordAgreement(opts, corpus) {
   return { records, participantCount: participants.length };
 }
 
-function heredocFencePairing(opts, corpus) {
+function heredocFencePairing(entries) {
   const records = [];
   let openerCount = 0;
-  for (const file of corpus) {
-    const lr = readLines(opts.root, file);
-    if (lr.error) continue; // already reported by autoScoreKeywordAgreement's read of the same file
-    const { regions, unterminated } = fencedRegions(lr.lines);
+  for (const { file, lines } of entries) {
+    const { regions, unterminated } = fencedRegions(lines);
     for (const startLine of unterminated) {
-      records.push({
-        invariant: 'sentinels',
-        file,
-        line: startLine + 1,
-        verdict: 'UNKNOWN',
-        message: 'fence opened here is never closed before EOF',
-      });
+      records.push(makeRecord('sentinels', file, startLine + 1, 'UNKNOWN', 'fence opened here is never closed before EOF'));
     }
-    lr.lines.forEach((line, idx) => {
+    const consumedTerminators = new Set();
+    lines.forEach((line, idx) => {
       const m = line.match(/<<'([^']+)'/);
       if (!m) return;
       openerCount++;
       const token = m[1];
       const region = regions.find((r) => idx > r.start && idx < r.end);
       if (!region) {
-        records.push({
-          invariant: 'sentinels',
-          file,
-          line: idx + 1,
-          verdict: 'FAIL',
-          message: `heredoc opener <<'${token}' is not inside a fenced code block`,
-        });
+        records.push(makeRecord('sentinels', file, idx + 1, 'FAIL', `heredoc opener <<'${token}' is not inside a fenced code block`));
         return;
       }
+      // An opener inside a fence that's still open at EOF isn't independently mis-terminated —
+      // the fence's own "never closed before EOF" UNKNOWN above already names the root cause.
+      if (!region.terminated) return;
       let terminators = 0;
+      let matchedLine = null;
       for (let i = region.start + 1; i < region.end; i++) {
-        if (lr.lines[i].trim() === token) terminators++;
+        if (consumedTerminators.has(i)) continue; // claimed by an earlier opener sharing this token+region
+        if (lines[i].trim() === token) {
+          terminators++;
+          if (matchedLine === null) matchedLine = i;
+        }
       }
-      if (terminators !== 1) {
-        records.push({
-          invariant: 'sentinels',
-          file,
-          line: idx + 1,
-          verdict: 'FAIL',
-          message: `heredoc opener <<'${token}' has ${terminators} terminator(s) in its fence, expected exactly 1`,
-        });
+      if (terminators === 1) {
+        consumedTerminators.add(matchedLine);
+      } else {
+        records.push(
+          makeRecord(
+            'sentinels',
+            file,
+            idx + 1,
+            'FAIL',
+            `heredoc opener <<'${token}' has ${terminators} terminator(s) in its fence, expected exactly 1`,
+          ),
+        );
       }
     });
   }
   if (openerCount === 0) {
-    records.push({
-      invariant: 'sentinels',
-      file: SENTINEL_CORPUS_DIRS.join(', '),
-      line: null,
-      verdict: 'UNKNOWN',
-      message: 'no heredoc openers found in the corpus',
-    });
+    records.push(makeRecord('sentinels', PROMPT_SURFACE_DIRS.join(', '), null, 'UNKNOWN', 'no heredoc openers found in the corpus'));
   }
   return { records, openerCount };
 }
 
 function sentinelsCheck(opts) {
-  const { files: corpus, errorRecords } = loadCorpus(opts, SENTINEL_CORPUS_DIRS);
-  const a = autoScoreKeywordAgreement(opts, corpus);
-  const b = heredocFencePairing(opts, corpus);
+  const { entries, errorRecords } = loadCorpus(opts, PROMPT_SURFACE_DIRS, 'sentinels');
+  const a = autoScoreKeywordAgreement(entries);
+  const b = heredocFencePairing(entries);
   const records = [...errorRecords, ...a.records, ...b.records];
   return {
     subjectCount: a.participantCount + b.openerCount,
@@ -275,8 +270,6 @@ function sentinelsCheck(opts) {
     records,
   };
 }
-
-const REFERENCES_SEARCH_DIRS = ['commands', 'agents'];
 
 // Top-level only — references/ is flat, and recursing would need walkMarkdown, whose recursion
 // this directory has no use for.
@@ -293,58 +286,54 @@ function referencesCheck(opts) {
   const records = [];
   const refRes = listReferenceFiles(opts.root);
   if (refRes.error) {
+    const message = `cannot list references/: ${refRes.error}`;
     return {
       subjectCount: 0,
       subjectNoun: 'reference files',
-      reason: `cannot list references/: ${refRes.error}`,
-      records: [
-        { invariant: 'references', file: 'references', line: null, verdict: 'UNKNOWN', message: `cannot list references/: ${refRes.error}` },
-      ],
+      reason: message,
+      records: [makeRecord('references', 'references', null, 'UNKNOWN', message)],
     };
   }
-  const { files: corpus, errorRecords } = loadCorpus(opts, REFERENCES_SEARCH_DIRS);
-  records.push(...errorRecords.map((r) => ({ ...r, invariant: 'references' })));
+  const { entries, errorRecords } = loadCorpus(opts, PROMPT_SURFACE_DIRS, 'references');
+  records.push(...errorRecords);
 
-  if (refRes.files.length === 0 || corpus.length === 0) {
-    records.push({
-      invariant: 'references',
-      file: 'references',
-      line: null,
-      verdict: 'UNKNOWN',
-      message: `empty references/ glob (${refRes.files.length}) or empty search corpus (${corpus.length})`,
-    });
+  if (refRes.files.length === 0 || entries.length === 0) {
+    records.push(
+      makeRecord(
+        'references',
+        'references',
+        null,
+        'UNKNOWN',
+        `empty references/ glob (${refRes.files.length}) or empty search corpus (${entries.length})`,
+      ),
+    );
     return { subjectCount: refRes.files.length, subjectNoun: 'reference files', reason: 'no subjects to check', records };
   }
-
-  const corpusText = corpus.map((file) => {
-    const lr = readLines(opts.root, file);
-    return lr.error ? [] : lr.lines;
-  });
 
   for (const refFile of refRes.files) {
     const basename = path.basename(refFile);
     const needle = `\`references/${basename}\``;
-    const cited = corpusText.some((lines) => lines.some((line) => line.includes(needle)));
+    const cited = entries.some(({ lines }) => lines.some((line) => line.includes(needle)));
     if (!cited) {
-      records.push({
-        invariant: 'references',
-        file: refFile,
-        line: null,
-        verdict: 'FAIL',
-        message: `no citation of ${needle} found in ${REFERENCES_SEARCH_DIRS.join('/, ')}/`,
-      });
+      records.push(
+        makeRecord(
+          'references',
+          refFile,
+          null,
+          'FAIL',
+          `no citation of ${needle} found in ${PROMPT_SURFACE_DIRS.join('/, ')}/`,
+        ),
+      );
     }
   }
 
   return {
     subjectCount: refRes.files.length,
     subjectNoun: 'reference files',
-    reason: `${refRes.files.length} reference file(s) checked against ${corpus.length} corpus file(s)`,
+    reason: `${refRes.files.length} reference file(s) checked against ${entries.length} corpus file(s)`,
     records,
   };
 }
-
-const VERSION_BUMP_WATCHED_PREFIXES = ['commands/', 'agents/', 'references/'];
 
 function gitRead(root, args, label) {
   try {
@@ -373,9 +362,7 @@ function versionBumpCheck(opts) {
     subjectCount: 0,
     subjectNoun: 'comparison inputs',
     reason: message,
-    records: [
-      { invariant: 'version-bump', file: '.claude-plugin/plugin.json', line: null, verdict: 'UNKNOWN', message },
-    ],
+    records: [makeRecord('version-bump', '.claude-plugin/plugin.json', null, 'UNKNOWN', message)],
   });
 
   const base = gitRead(opts.root, ['rev-parse', '--verify', 'HEAD~1^{commit}'], 'git rev-parse HEAD~1');
@@ -387,19 +374,12 @@ function versionBumpCheck(opts) {
   const touchesWatched = changedPaths.some((p) => VERSION_BUMP_WATCHED_PREFIXES.some((prefix) => p.startsWith(prefix)));
 
   if (!touchesWatched) {
+    const reason = 'not applicable — no prompt-surface paths changed';
     return {
       subjectCount: 3,
       subjectNoun: 'comparison inputs',
-      reason: 'not applicable — no prompt-surface paths changed',
-      records: [
-        {
-          invariant: 'version-bump',
-          file: '.claude-plugin/plugin.json',
-          line: null,
-          verdict: 'PASS',
-          message: 'not applicable — no prompt-surface paths changed',
-        },
-      ],
+      reason,
+      records: [makeRecord('version-bump', '.claude-plugin/plugin.json', null, 'PASS', reason)],
     };
   }
 
@@ -419,9 +399,7 @@ function versionBumpCheck(opts) {
       subjectCount: 3,
       subjectNoun: 'comparison inputs',
       reason: message,
-      records: [
-        { invariant: 'version-bump', file: '.claude-plugin/plugin.json', line: null, verdict: 'FAIL', message },
-      ],
+      records: [makeRecord('version-bump', '.claude-plugin/plugin.json', null, 'FAIL', message)],
     };
   }
 
@@ -430,26 +408,7 @@ function versionBumpCheck(opts) {
     subjectCount: 3,
     subjectNoun: 'comparison inputs',
     reason,
-    records: [
-      { invariant: 'version-bump', file: '.claude-plugin/plugin.json', line: null, verdict: 'PASS', message: reason },
-    ],
-  };
-}
-
-function notImplemented(id) {
-  return {
-    subjectCount: 0,
-    subjectNoun: 'subjects',
-    reason: 'check not implemented yet',
-    records: [
-      {
-        invariant: id,
-        file: 'scripts/check-invariants.mjs',
-        line: null,
-        verdict: 'UNKNOWN',
-        message: 'check not implemented yet',
-      },
-    ],
+    records: [makeRecord('version-bump', '.claude-plugin/plugin.json', null, 'PASS', reason)],
   };
 }
 

--- a/scripts/check-invariants.mjs
+++ b/scripts/check-invariants.mjs
@@ -76,6 +76,206 @@ function walkMarkdown(root, relDir) {
   return { files };
 }
 
+const SENTINEL_CORPUS_DIRS = ['commands', 'agents'];
+const ALLOWED_AUTO_SCORE_KEYWORDS = new Set(['clean', 'weak', 'error']);
+
+function fenceMatch(line) {
+  const m = line.match(/^ {0,3}(`{3,}|~{3,})/);
+  if (!m) return null;
+  return { char: m[1][0], length: m[1].length };
+}
+
+// Only its own consumer (the heredoc sub-assertion) needs fence boundaries, so it lives here.
+// Tracks fence character and run length (not just "inside a fence") because the corpus has
+// four-backtick fences containing nested three-backtick fences — a length-blind scanner would
+// close on the inner fence and mis-split the region.
+function fencedRegions(lines) {
+  const regions = [];
+  const unterminated = [];
+  let open = null;
+  for (let i = 0; i < lines.length; i++) {
+    if (!open) {
+      const m = fenceMatch(lines[i]);
+      if (m) open = { ...m, start: i };
+      continue;
+    }
+    const trimmed = lines[i].trim();
+    const isCloser =
+      trimmed.length > 0 &&
+      trimmed.length >= open.length &&
+      [...trimmed].every((c) => c === open.char);
+    if (isCloser) {
+      regions.push({ start: open.start, end: i });
+      open = null;
+    }
+  }
+  if (open) unterminated.push(open.start);
+  return { regions, unterminated };
+}
+
+function loadCorpus(opts, dirs) {
+  const files = [];
+  const errorRecords = [];
+  for (const dir of dirs) {
+    const res = walkMarkdown(opts.root, dir);
+    if (res.error) {
+      errorRecords.push({
+        invariant: 'sentinels',
+        file: dir,
+        line: null,
+        verdict: 'UNKNOWN',
+        message: `cannot list directory: ${res.error}`,
+      });
+      continue;
+    }
+    files.push(...res.files);
+  }
+  return { files, errorRecords };
+}
+
+function autoScoreKeywordAgreement(opts, corpus) {
+  const records = [];
+  const participants = [];
+  for (const file of corpus) {
+    const lr = readLines(opts.root, file);
+    if (lr.error) {
+      records.push({
+        invariant: 'sentinels',
+        file,
+        line: null,
+        verdict: 'UNKNOWN',
+        message: `cannot read file: ${lr.error}`,
+      });
+      continue;
+    }
+    const keywords = new Map();
+    lr.lines.forEach((line, idx) => {
+      const re = /\[AUTO-SCORE:\s*([a-z]+)/g;
+      let m;
+      while ((m = re.exec(line))) {
+        if (!keywords.has(m[1])) keywords.set(m[1], idx + 1);
+      }
+    });
+    if (keywords.size > 0) participants.push({ file, keywords });
+  }
+
+  if (participants.length < 2) {
+    records.push({
+      invariant: 'sentinels',
+      file: SENTINEL_CORPUS_DIRS.join(', '),
+      line: null,
+      verdict: 'UNKNOWN',
+      message: `expected an emitter and a parser, found ${participants.length}`,
+    });
+    return { records, participantCount: participants.length };
+  }
+
+  for (const p of participants) {
+    for (const [kw, line] of p.keywords) {
+      if (!ALLOWED_AUTO_SCORE_KEYWORDS.has(kw)) {
+        records.push({
+          invariant: 'sentinels',
+          file: p.file,
+          line,
+          verdict: 'FAIL',
+          message: `[AUTO-SCORE: ${kw}] is outside {clean, weak, error}`,
+        });
+      }
+    }
+  }
+
+  for (const a of participants) {
+    for (const b of participants) {
+      if (a === b) continue;
+      for (const [kw, bLine] of b.keywords) {
+        if (!a.keywords.has(kw)) {
+          records.push({
+            invariant: 'sentinels',
+            file: a.file,
+            line: bLine,
+            verdict: 'FAIL',
+            message: `keyword set differs from ${b.file}: missing '${kw}' (present at ${b.file}:${bLine})`,
+          });
+        }
+      }
+    }
+  }
+
+  return { records, participantCount: participants.length };
+}
+
+function heredocFencePairing(opts, corpus) {
+  const records = [];
+  let openerCount = 0;
+  for (const file of corpus) {
+    const lr = readLines(opts.root, file);
+    if (lr.error) continue; // already reported by autoScoreKeywordAgreement's read of the same file
+    const { regions, unterminated } = fencedRegions(lr.lines);
+    for (const startLine of unterminated) {
+      records.push({
+        invariant: 'sentinels',
+        file,
+        line: startLine + 1,
+        verdict: 'UNKNOWN',
+        message: 'fence opened here is never closed before EOF',
+      });
+    }
+    lr.lines.forEach((line, idx) => {
+      const m = line.match(/<<'([^']+)'/);
+      if (!m) return;
+      openerCount++;
+      const token = m[1];
+      const region = regions.find((r) => idx > r.start && idx < r.end);
+      if (!region) {
+        records.push({
+          invariant: 'sentinels',
+          file,
+          line: idx + 1,
+          verdict: 'FAIL',
+          message: `heredoc opener <<'${token}' is not inside a fenced code block`,
+        });
+        return;
+      }
+      let terminators = 0;
+      for (let i = region.start + 1; i < region.end; i++) {
+        if (lr.lines[i].trim() === token) terminators++;
+      }
+      if (terminators !== 1) {
+        records.push({
+          invariant: 'sentinels',
+          file,
+          line: idx + 1,
+          verdict: 'FAIL',
+          message: `heredoc opener <<'${token}' has ${terminators} terminator(s) in its fence, expected exactly 1`,
+        });
+      }
+    });
+  }
+  if (openerCount === 0) {
+    records.push({
+      invariant: 'sentinels',
+      file: SENTINEL_CORPUS_DIRS.join(', '),
+      line: null,
+      verdict: 'UNKNOWN',
+      message: 'no heredoc openers found in the corpus',
+    });
+  }
+  return { records, openerCount };
+}
+
+function sentinelsCheck(opts) {
+  const { files: corpus, errorRecords } = loadCorpus(opts, SENTINEL_CORPUS_DIRS);
+  const a = autoScoreKeywordAgreement(opts, corpus);
+  const b = heredocFencePairing(opts, corpus);
+  const records = [...errorRecords, ...a.records, ...b.records];
+  return {
+    subjectCount: a.participantCount + b.openerCount,
+    subjectNoun: 'subjects',
+    reason: `${a.participantCount} AUTO-SCORE participant(s), ${b.openerCount} heredoc opener(s)`,
+    records,
+  };
+}
+
 function notImplemented(id) {
   return {
     subjectCount: 0,
@@ -94,7 +294,7 @@ function notImplemented(id) {
 }
 
 const CHECKS = [
-  { id: 'sentinels', run: () => notImplemented('sentinels') },
+  { id: 'sentinels', run: sentinelsCheck },
   { id: 'references', run: () => notImplemented('references') },
   { id: 'version-bump', run: () => notImplemented('version-bump') },
 ];

--- a/scripts/check-invariants.mjs
+++ b/scripts/check-invariants.mjs
@@ -116,6 +116,16 @@ function fenceMatch(line) {
   return { char: m[1][0], length: m[1].length };
 }
 
+// A closer has the same 0-3-space indentation cap as an opener (CommonMark), plus no info
+// string — trimming all leading whitespace before comparing (the prior approach) accepted a
+// closer indented arbitrarily far, letting fence *content* that happened to repeat the fence
+// character prematurely end the region.
+function fenceCloseMatch(line, char, minLength) {
+  const re = char === '`' ? /^ {0,3}(`{3,})\s*$/ : /^ {0,3}(~{3,})\s*$/;
+  const m = line.match(re);
+  return m != null && m[1].length >= minLength;
+}
+
 // Tracks fence character and run length (not just "inside a fence") because the corpus has
 // four-backtick fences containing nested three-backtick fences — a length-blind scanner would
 // close on the inner fence and mis-split the region. A fence still open at EOF still yields a
@@ -131,12 +141,7 @@ function fencedRegions(lines) {
       if (m) open = { ...m, start: i };
       continue;
     }
-    const trimmed = lines[i].trim();
-    const isCloser =
-      trimmed.length > 0 &&
-      trimmed.length >= open.length &&
-      [...trimmed].every((c) => c === open.char);
-    if (isCloser) {
+    if (fenceCloseMatch(lines[i], open.char, open.length)) {
       regions.push({ start: open.start, end: i, terminated: true });
       open = null;
     }

--- a/scripts/check-invariants.mjs
+++ b/scripts/check-invariants.mjs
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+
+const VERDICT_CODE = { PASS: 0, FAIL: 1, UNKNOWN: 2 };
+
+function formatRecord(r) {
+  const loc = r.line != null ? `${r.file}:${r.line}` : r.file;
+  return `${r.invariant} — ${loc} — ${r.message}`;
+}
+
+// FAIL outranks UNKNOWN — a broken invariant must read as "broken", not "couldn't tell".
+function verdictForRecords(records) {
+  if (records.some((r) => r.verdict === 'FAIL')) return 'FAIL';
+  if (records.some((r) => r.verdict === 'UNKNOWN')) return 'UNKNOWN';
+  return 'PASS';
+}
+
+function exitCodeForRecords(records) {
+  return VERDICT_CODE[verdictForRecords(records)];
+}
+
+function usage() {
+  return 'Usage: check-invariants.mjs [--only <id>] [--root <dir>]';
+}
+
+function parseArgs(argv) {
+  const opts = { only: null, root: process.cwd() };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--only') opts.only = argv[++i];
+    else if (a === '--root') opts.root = argv[++i];
+    else {
+      console.error(`Unknown flag: ${a}\n${usage()}`);
+      return null;
+    }
+  }
+  return opts;
+}
+
+// Returns an error result rather than throwing, so callers can produce a named UNKNOWN record.
+function readLines(root, relPath) {
+  try {
+    const text = fs.readFileSync(path.join(root, relPath), 'utf8');
+    return { lines: text.split('\n') };
+  } catch (err) {
+    return { error: String((err && err.message) || err) };
+  }
+}
+
+// Recursive so one helper serves both the flat agents/ and the nested commands/ba/;
+// returns an error result rather than throwing on a missing relDir.
+function walkMarkdown(root, relDir) {
+  const files = [];
+  function walk(dir) {
+    let entries;
+    try {
+      entries = fs.readdirSync(path.join(root, dir), { withFileTypes: true });
+    } catch (err) {
+      throw { relDir: dir, error: String((err && err.message) || err) };
+    }
+    for (const entry of entries) {
+      const relPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) walk(relPath);
+      else if (entry.isFile() && entry.name.endsWith('.md')) files.push(relPath);
+    }
+  }
+  try {
+    walk(relDir);
+  } catch (e) {
+    return { error: e.error, relDir: e.relDir };
+  }
+  files.sort();
+  return { files };
+}
+
+function notImplemented(id) {
+  return {
+    subjectCount: 0,
+    subjectNoun: 'subjects',
+    reason: 'check not implemented yet',
+    records: [
+      {
+        invariant: id,
+        file: 'scripts/check-invariants.mjs',
+        line: null,
+        verdict: 'UNKNOWN',
+        message: 'check not implemented yet',
+      },
+    ],
+  };
+}
+
+const CHECKS = [
+  { id: 'sentinels', run: () => notImplemented('sentinels') },
+  { id: 'references', run: () => notImplemented('references') },
+  { id: 'version-bump', run: () => notImplemented('version-bump') },
+];
+
+function runChecks(opts) {
+  const checks = opts.only ? CHECKS.filter((c) => c.id === opts.only) : CHECKS;
+  if (opts.only && checks.length === 0) {
+    console.error(`Unknown check id: ${opts.only}`);
+    return null;
+  }
+  return checks.map((c) => ({ id: c.id, ...c.run(opts) }));
+}
+
+// Every verdict line prints, PASS included, with a mandatory reason — two PASSes with the
+// same subject count can mean different things (e.g. version-bump's "not applicable" vs.
+// "version bumped"), and an indistinguishable line reintroduces the vacuous green one level up.
+function report(results) {
+  for (const r of results) {
+    const verdict = verdictForRecords(r.records);
+    console.log(`${r.id}: ${verdict} (${r.subjectCount} ${r.subjectNoun}) — ${r.reason}`);
+  }
+  for (const r of results) {
+    for (const rec of r.records.filter((x) => x.verdict !== 'PASS')) {
+      console.log(formatRecord(rec));
+    }
+  }
+}
+
+function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  if (!opts) {
+    process.exitCode = 2;
+    return;
+  }
+  try {
+    const results = runChecks(opts);
+    if (results === null) {
+      process.exitCode = 2;
+      return;
+    }
+    report(results);
+    const allRecords = results.flatMap((r) => r.records);
+    process.exitCode = exitCodeForRecords(allRecords);
+  } catch (err) {
+    console.error(String((err && err.stack) || err));
+    process.exitCode = 2;
+  }
+}
+
+main();

--- a/scripts/check-invariants.mjs
+++ b/scripts/check-invariants.mjs
@@ -344,6 +344,98 @@ function referencesCheck(opts) {
   };
 }
 
+const VERSION_BUMP_WATCHED_PREFIXES = ['commands/', 'agents/', 'references/'];
+
+function gitRead(root, args, label) {
+  try {
+    return { value: execFileSync('git', args, { cwd: root, encoding: 'utf8' }) };
+  } catch (err) {
+    return { error: `${label} failed: ${String((err && err.message) || err).split('\n')[0]}` };
+  }
+}
+
+function parsePluginVersion(blobText, label) {
+  let parsed;
+  try {
+    parsed = JSON.parse(blobText);
+  } catch (err) {
+    return { error: `${label}: plugin.json did not parse as JSON` };
+  }
+  const version = parsed.version;
+  if (typeof version !== 'string' || version.trim() === '') {
+    return { error: `${label}: 'version' is missing or not a non-empty string` };
+  }
+  return { value: version.trim() };
+}
+
+function versionBumpCheck(opts) {
+  const unknown = (message) => ({
+    subjectCount: 0,
+    subjectNoun: 'comparison inputs',
+    reason: message,
+    records: [
+      { invariant: 'version-bump', file: '.claude-plugin/plugin.json', line: null, verdict: 'UNKNOWN', message },
+    ],
+  });
+
+  const base = gitRead(opts.root, ['rev-parse', '--verify', 'HEAD~1^{commit}'], 'git rev-parse HEAD~1');
+  if (base.error) return unknown(base.error);
+
+  const diff = gitRead(opts.root, ['diff', '--name-only', 'HEAD~1', 'HEAD'], 'git diff --name-only');
+  if (diff.error) return unknown(diff.error);
+  const changedPaths = diff.value.split('\n').filter(Boolean);
+  const touchesWatched = changedPaths.some((p) => VERSION_BUMP_WATCHED_PREFIXES.some((prefix) => p.startsWith(prefix)));
+
+  if (!touchesWatched) {
+    return {
+      subjectCount: 3,
+      subjectNoun: 'comparison inputs',
+      reason: 'not applicable — no prompt-surface paths changed',
+      records: [
+        {
+          invariant: 'version-bump',
+          file: '.claude-plugin/plugin.json',
+          line: null,
+          verdict: 'PASS',
+          message: 'not applicable — no prompt-surface paths changed',
+        },
+      ],
+    };
+  }
+
+  const oldBlob = gitRead(opts.root, ['show', 'HEAD~1:.claude-plugin/plugin.json'], 'git show HEAD~1:.claude-plugin/plugin.json');
+  if (oldBlob.error) return unknown(oldBlob.error);
+  const newBlob = gitRead(opts.root, ['show', 'HEAD:.claude-plugin/plugin.json'], 'git show HEAD:.claude-plugin/plugin.json');
+  if (newBlob.error) return unknown(newBlob.error);
+
+  const oldVersion = parsePluginVersion(oldBlob.value, 'HEAD~1');
+  if (oldVersion.error) return unknown(oldVersion.error);
+  const newVersion = parsePluginVersion(newBlob.value, 'HEAD');
+  if (newVersion.error) return unknown(newVersion.error);
+
+  if (oldVersion.value === newVersion.value) {
+    const message = `version unchanged (${oldVersion.value}) while commands/, agents/, or references/ changed`;
+    return {
+      subjectCount: 3,
+      subjectNoun: 'comparison inputs',
+      reason: message,
+      records: [
+        { invariant: 'version-bump', file: '.claude-plugin/plugin.json', line: null, verdict: 'FAIL', message },
+      ],
+    };
+  }
+
+  const reason = `version ${oldVersion.value} → ${newVersion.value}`;
+  return {
+    subjectCount: 3,
+    subjectNoun: 'comparison inputs',
+    reason,
+    records: [
+      { invariant: 'version-bump', file: '.claude-plugin/plugin.json', line: null, verdict: 'PASS', message: reason },
+    ],
+  };
+}
+
 function notImplemented(id) {
   return {
     subjectCount: 0,
@@ -364,7 +456,7 @@ function notImplemented(id) {
 const CHECKS = [
   { id: 'sentinels', run: sentinelsCheck },
   { id: 'references', run: referencesCheck },
-  { id: 'version-bump', run: () => notImplemented('version-bump') },
+  { id: 'version-bump', run: versionBumpCheck },
 ];
 
 function runChecks(opts) {

--- a/scripts/check-invariants.mjs
+++ b/scripts/check-invariants.mjs
@@ -276,6 +276,74 @@ function sentinelsCheck(opts) {
   };
 }
 
+const REFERENCES_SEARCH_DIRS = ['commands', 'agents'];
+
+// Top-level only — references/ is flat, and recursing would need walkMarkdown, whose recursion
+// this directory has no use for.
+function listReferenceFiles(root) {
+  try {
+    const entries = fs.readdirSync(path.join(root, 'references'), { withFileTypes: true });
+    return { files: entries.filter((e) => e.isFile() && e.name.endsWith('.md')).map((e) => `references/${e.name}`).sort() };
+  } catch (err) {
+    return { error: String((err && err.message) || err) };
+  }
+}
+
+function referencesCheck(opts) {
+  const records = [];
+  const refRes = listReferenceFiles(opts.root);
+  if (refRes.error) {
+    return {
+      subjectCount: 0,
+      subjectNoun: 'reference files',
+      reason: `cannot list references/: ${refRes.error}`,
+      records: [
+        { invariant: 'references', file: 'references', line: null, verdict: 'UNKNOWN', message: `cannot list references/: ${refRes.error}` },
+      ],
+    };
+  }
+  const { files: corpus, errorRecords } = loadCorpus(opts, REFERENCES_SEARCH_DIRS);
+  records.push(...errorRecords.map((r) => ({ ...r, invariant: 'references' })));
+
+  if (refRes.files.length === 0 || corpus.length === 0) {
+    records.push({
+      invariant: 'references',
+      file: 'references',
+      line: null,
+      verdict: 'UNKNOWN',
+      message: `empty references/ glob (${refRes.files.length}) or empty search corpus (${corpus.length})`,
+    });
+    return { subjectCount: refRes.files.length, subjectNoun: 'reference files', reason: 'no subjects to check', records };
+  }
+
+  const corpusText = corpus.map((file) => {
+    const lr = readLines(opts.root, file);
+    return lr.error ? [] : lr.lines;
+  });
+
+  for (const refFile of refRes.files) {
+    const basename = path.basename(refFile);
+    const needle = `\`references/${basename}\``;
+    const cited = corpusText.some((lines) => lines.some((line) => line.includes(needle)));
+    if (!cited) {
+      records.push({
+        invariant: 'references',
+        file: refFile,
+        line: null,
+        verdict: 'FAIL',
+        message: `no citation of ${needle} found in ${REFERENCES_SEARCH_DIRS.join('/, ')}/`,
+      });
+    }
+  }
+
+  return {
+    subjectCount: refRes.files.length,
+    subjectNoun: 'reference files',
+    reason: `${refRes.files.length} reference file(s) checked against ${corpus.length} corpus file(s)`,
+    records,
+  };
+}
+
 function notImplemented(id) {
   return {
     subjectCount: 0,
@@ -295,7 +363,7 @@ function notImplemented(id) {
 
 const CHECKS = [
   { id: 'sentinels', run: sentinelsCheck },
-  { id: 'references', run: () => notImplemented('references') },
+  { id: 'references', run: referencesCheck },
   { id: 'version-bump', run: () => notImplemented('version-bump') },
 ];
 

--- a/scripts/selfcheck-invariants.mjs
+++ b/scripts/selfcheck-invariants.mjs
@@ -27,12 +27,16 @@ function gitCommit(root, message) {
   );
 }
 
+// Combines stdout+stderr into one string: normal check output goes to stdout, but parse
+// errors (e.g. an unknown --only id) are written to stderr, and case assertions need to see both.
 function runChecker(root, checkId) {
+  const args = [CHECKER, '--root', root];
+  if (checkId) args.push('--only', checkId);
   try {
-    const stdout = execFileSync('node', [CHECKER, '--root', root, '--only', checkId], { encoding: 'utf8' });
+    const stdout = execFileSync('node', args, { encoding: 'utf8' });
     return { exitCode: 0, stdout };
   } catch (err) {
-    return { exitCode: err.status, stdout: err.stdout ?? '' };
+    return { exitCode: err.status, stdout: (err.stdout ?? '') + (err.stderr ?? '') };
   }
 }
 
@@ -256,6 +260,29 @@ const CASES = [
     expectExit: 2,
     expectSubstring: 'cannot list directory',
   },
+  {
+    name: 'no --only: all three checks run and their verdicts fold with FAIL outranking UNKNOWN',
+    checkId: null,
+    build(root) {
+      write(
+        root,
+        'commands/a.md',
+        "[AUTO-SCORE: clean]\n[AUTO-SCORE: weak]\n[AUTO-SCORE: error]\n```bash\ncat <<'TOKEN'\nbody\nTOKEN\n```\n",
+      );
+      write(root, 'agents/b.md', '[AUTO-SCORE: clean]\n[AUTO-SCORE: weak]\n[AUTO-SCORE: error]\n');
+      write(root, 'references/foo.md', 'content\n'); // cited nowhere -> references FAIL
+      // no git repo at all -> version-bump UNKNOWN; sentinels PASSes -> overall exit must be FAIL (1), not UNKNOWN (2)
+    },
+    expectExit: 1,
+    expectSubstrings: ['sentinels: PASS', 'references: FAIL', 'version-bump: UNKNOWN'],
+  },
+  {
+    name: '--only bogus: unknown check id reports an error and exits 2',
+    checkId: 'bogus',
+    build() {},
+    expectExit: 2,
+    expectSubstring: 'Unknown check id: bogus',
+  },
 ];
 
 function main() {
@@ -263,19 +290,26 @@ function main() {
   for (const c of CASES) {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ba-invariants-'));
     try {
+      const expected = c.expectSubstrings ?? [c.expectSubstring];
       c.build(root);
       const { exitCode, stdout } = runChecker(root, c.checkId);
       const exitOk = exitCode === c.expectExit;
-      const substringOk = stdout.includes(c.expectSubstring);
+      const substringOk = expected.every((s) => stdout.includes(s));
       if (exitOk && substringOk) {
         console.log(`PASS: ${c.name}`);
       } else {
         failures++;
         console.log(`FAIL: ${c.name}`);
         console.log(`  expected exit ${c.expectExit}, got ${exitCode}`);
-        console.log(`  expected stdout to include: ${c.expectSubstring}`);
+        console.log(`  expected stdout to include: ${expected.join(' AND ')}`);
         console.log(`  actual stdout:\n${stdout}`);
       }
+    } catch (err) {
+      // A case's own build() (e.g. gitInit/gitCommit) throwing must not abort the remaining
+      // cases — record it as a failure and keep going, same as an assertion mismatch.
+      failures++;
+      console.log(`FAIL: ${c.name}`);
+      console.log(`  case threw: ${String((err && err.stack) || err)}`);
     } finally {
       fs.rmSync(root, { recursive: true, force: true });
     }

--- a/scripts/selfcheck-invariants.mjs
+++ b/scripts/selfcheck-invariants.mjs
@@ -29,11 +29,16 @@ function gitCommit(root, message) {
 
 // Combines stdout+stderr into one string: normal check output goes to stdout, but parse
 // errors (e.g. an unknown --only id) are written to stderr, and case assertions need to see both.
-function runChecker(root, checkId) {
+// Uses process.execPath (not the bare "node") so a case can strip PATH via envOverride to
+// simulate git being absent without also breaking Node's own resolution of the checker.
+function runChecker(root, checkId, envOverride) {
   const args = [CHECKER, '--root', root];
   if (checkId) args.push('--only', checkId);
   try {
-    const stdout = execFileSync('node', args, { encoding: 'utf8' });
+    const stdout = execFileSync(process.execPath, args, {
+      encoding: 'utf8',
+      env: envOverride ? { ...process.env, ...envOverride } : process.env,
+    });
     return { exitCode: 0, stdout };
   } catch (err) {
     return { exitCode: err.status, stdout: (err.stdout ?? '') + (err.stderr ?? '') };
@@ -252,13 +257,46 @@ const CASES = [
     expectSubstring: 'git rev-parse HEAD~1 failed',
   },
   {
-    name: 'any check UNKNOWN — --root with no commands/ directory yields a named record',
+    name: 'sentinels UNKNOWN — --root with no commands/ directory yields a named record',
     checkId: 'sentinels',
     build(root) {
       fs.mkdirSync(path.join(root, 'agents'), { recursive: true });
     },
     expectExit: 2,
     expectSubstring: 'cannot list directory',
+  },
+  {
+    name: 'references UNKNOWN — --root with no commands/ directory yields a named record too',
+    checkId: 'references',
+    build(root) {
+      fs.mkdirSync(path.join(root, 'agents'), { recursive: true });
+      write(root, 'references/foo.md', 'content\n');
+    },
+    expectExit: 2,
+    expectSubstring: 'cannot list directory',
+  },
+  {
+    name: 'sentinels PASS — an over-indented closer (>3 spaces) does not prematurely end the fence',
+    checkId: 'sentinels',
+    build(root) {
+      write(root, 'commands/a.md', '[AUTO-SCORE: clean]\n[AUTO-SCORE: weak]\n[AUTO-SCORE: error]\n');
+      write(root, 'agents/b.md', '[AUTO-SCORE: clean]\n[AUTO-SCORE: weak]\n[AUTO-SCORE: error]\n');
+      write(
+        root,
+        'commands/c.md',
+        "```bash\ncat <<'TOKEN'\nbody\n            ```\nTOKEN\n```\n",
+      );
+    },
+    expectExit: 0,
+    expectSubstring: 'sentinels: PASS',
+  },
+  {
+    name: 'version-bump UNKNOWN — git absent from PATH',
+    checkId: 'version-bump',
+    build() {},
+    expectExit: 2,
+    expectSubstring: 'git rev-parse HEAD~1 failed',
+    env: { PATH: '' },
   },
   {
     name: 'no --only: all three checks run and their verdicts fold with FAIL outranking UNKNOWN',
@@ -285,14 +323,41 @@ const CASES = [
   },
 ];
 
+// Static, not a checker invocation: greps the two scripts' own import lines rather than
+// building a tree and running the checker, since AC7 is a property of the source files
+// themselves, not of any check's behavior against a corpus.
+function checkStdlibImportsOnly() {
+  const name = 'both scripts import only Node built-in modules (AC7)';
+  const files = ['check-invariants.mjs', 'selfcheck-invariants.mjs'].map((f) =>
+    fileURLToPath(new URL(`./${f}`, import.meta.url)),
+  );
+  const offenders = [];
+  for (const file of files) {
+    const text = fs.readFileSync(file, 'utf8');
+    const importRe = /^import .* from ['"]([^'"]+)['"];?$/gm;
+    let m;
+    while ((m = importRe.exec(text))) {
+      if (!m[1].startsWith('node:')) offenders.push(`${path.basename(file)}: ${m[1]}`);
+    }
+  }
+  if (offenders.length === 0) {
+    console.log(`PASS: ${name}`);
+    return true;
+  }
+  console.log(`FAIL: ${name}`);
+  console.log(`  non-builtin imports: ${offenders.join(', ')}`);
+  return false;
+}
+
 function main() {
   let failures = 0;
+  if (!checkStdlibImportsOnly()) failures++;
   for (const c of CASES) {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ba-invariants-'));
     try {
       const expected = c.expectSubstrings ?? [c.expectSubstring];
       c.build(root);
-      const { exitCode, stdout } = runChecker(root, c.checkId);
+      const { exitCode, stdout } = runChecker(root, c.checkId, c.env);
       const exitOk = exitCode === c.expectExit;
       const substringOk = expected.every((s) => stdout.includes(s));
       if (exitOk && substringOk) {
@@ -314,11 +379,12 @@ function main() {
       fs.rmSync(root, { recursive: true, force: true });
     }
   }
+  const totalChecks = CASES.length + 1; // +1 for checkStdlibImportsOnly
   if (failures > 0) {
-    console.error(`${failures}/${CASES.length} selfcheck case(s) failed.`);
+    console.error(`${failures}/${totalChecks} selfcheck check(s) failed.`);
     process.exitCode = 1;
   } else {
-    console.log(`All ${CASES.length} selfcheck cases passed.`);
+    console.log(`All ${totalChecks} selfcheck checks passed.`);
   }
 }
 

--- a/scripts/selfcheck-invariants.mjs
+++ b/scripts/selfcheck-invariants.mjs
@@ -1,0 +1,291 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execFileSync } from 'node:child_process';
+
+const CHECKER = fileURLToPath(new URL('./check-invariants.mjs', import.meta.url));
+
+function write(root, relPath, content) {
+  const full = path.join(root, relPath);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, content);
+}
+
+function gitInit(root) {
+  execFileSync('git', ['init', '-q'], { cwd: root });
+}
+
+function gitCommit(root, message) {
+  execFileSync('git', ['add', '-A'], { cwd: root });
+  execFileSync(
+    'git',
+    ['-c', 'user.email=selfcheck@example.com', '-c', 'user.name=selfcheck', 'commit', '-q', '-m', message, '--no-gpg-sign'],
+    { cwd: root },
+  );
+}
+
+function runChecker(root, checkId) {
+  try {
+    const stdout = execFileSync('node', [CHECKER, '--root', root, '--only', checkId], { encoding: 'utf8' });
+    return { exitCode: 0, stdout };
+  } catch (err) {
+    return { exitCode: err.status, stdout: err.stdout ?? '' };
+  }
+}
+
+const CASES = [
+  {
+    name: 'sentinels FAIL — differing AUTO-SCORE keyword sets',
+    checkId: 'sentinels',
+    build(root) {
+      write(root, 'commands/a.md', '[AUTO-SCORE: clean]\n[AUTO-SCORE: weak]\n');
+      write(root, 'agents/b.md', '[AUTO-SCORE: clean]\n[AUTO-SCORE: weak]\n[AUTO-SCORE: error]\n');
+    },
+    expectExit: 1,
+    expectSubstring: 'keyword set differs',
+  },
+  {
+    name: 'sentinels FAIL — [AUTO-SCORE: warn] outside allowed set',
+    checkId: 'sentinels',
+    build(root) {
+      write(root, 'commands/a.md', '[AUTO-SCORE: clean]\n[AUTO-SCORE: weak]\n[AUTO-SCORE: error]\n');
+      write(root, 'agents/b.md', '[AUTO-SCORE: clean]\n[AUTO-SCORE: weak]\n[AUTO-SCORE: warn]\n');
+    },
+    expectExit: 1,
+    expectSubstring: 'is outside {clean, weak, error}',
+  },
+  {
+    name: 'sentinels FAIL — heredoc opener with no terminator in its fence',
+    checkId: 'sentinels',
+    build(root) {
+      write(root, 'commands/a.md', '[AUTO-SCORE: clean]\n[AUTO-SCORE: weak]\n[AUTO-SCORE: error]\n');
+      write(root, 'agents/b.md', '[AUTO-SCORE: clean]\n[AUTO-SCORE: weak]\n[AUTO-SCORE: error]\n');
+      write(root, 'commands/c.md', "```bash\ncat <<'TOKEN'\nno terminator here\n```\n");
+    },
+    expectExit: 1,
+    expectSubstring: 'terminator(s) in its fence, expected exactly 1',
+  },
+  {
+    name: 'sentinels PASS — heredoc paired across a nested fence via run-length',
+    checkId: 'sentinels',
+    build(root) {
+      write(root, 'commands/a.md', '[AUTO-SCORE: clean]\n[AUTO-SCORE: weak]\n[AUTO-SCORE: error]\n');
+      write(root, 'agents/b.md', '[AUTO-SCORE: clean]\n[AUTO-SCORE: weak]\n[AUTO-SCORE: error]\n');
+      write(
+        root,
+        'commands/c.md',
+        "````bash\ncat <<'TOKEN'\n```\nnested three-backtick fence\n```\nTOKEN\n````\n",
+      );
+    },
+    expectExit: 0,
+    expectSubstring: 'sentinels: PASS',
+  },
+  {
+    name: 'sentinels PASS — bare-line token outside any fence is not a terminator',
+    checkId: 'sentinels',
+    build(root) {
+      write(root, 'commands/a.md', '[AUTO-SCORE: clean]\n[AUTO-SCORE: weak]\n[AUTO-SCORE: error]\n');
+      write(root, 'agents/b.md', '[AUTO-SCORE: clean]\n[AUTO-SCORE: weak]\n[AUTO-SCORE: error]\n');
+      write(
+        root,
+        'commands/c.md',
+        "```bash\ncat <<'TOKEN'\nbody\nTOKEN\n```\n\nTOKEN\n",
+      );
+    },
+    expectExit: 0,
+    expectSubstring: 'sentinels: PASS',
+  },
+  {
+    name: 'sentinels UNKNOWN — fewer than two AUTO-SCORE participants',
+    checkId: 'sentinels',
+    build(root) {
+      write(root, 'commands/a.md', '[AUTO-SCORE: clean]\n[AUTO-SCORE: weak]\n[AUTO-SCORE: error]\n');
+      write(root, 'agents/b.md', 'no sentinel here\n');
+    },
+    expectExit: 2,
+    expectSubstring: 'expected an emitter and a parser, found 1',
+  },
+  {
+    name: 'sentinels UNKNOWN — no heredoc openers in the corpus',
+    checkId: 'sentinels',
+    build(root) {
+      write(root, 'commands/a.md', '[AUTO-SCORE: clean]\n[AUTO-SCORE: weak]\n[AUTO-SCORE: error]\n');
+      write(root, 'agents/b.md', '[AUTO-SCORE: clean]\n[AUTO-SCORE: weak]\n[AUTO-SCORE: error]\n');
+    },
+    expectExit: 2,
+    expectSubstring: 'no heredoc openers found',
+  },
+  {
+    name: 'sentinels UNKNOWN — fence left open at EOF',
+    checkId: 'sentinels',
+    build(root) {
+      write(root, 'commands/a.md', '[AUTO-SCORE: clean]\n[AUTO-SCORE: weak]\n[AUTO-SCORE: error]\n');
+      write(root, 'agents/b.md', '[AUTO-SCORE: clean]\n[AUTO-SCORE: weak]\n[AUTO-SCORE: error]\n');
+      write(root, 'commands/c.md', '```bash\necho hi\n');
+    },
+    expectExit: 2,
+    expectSubstring: 'never closed before EOF',
+  },
+  {
+    name: 'references FAIL — reference cited nowhere',
+    checkId: 'references',
+    build(root) {
+      write(root, 'references/foo.md', 'content\n');
+      write(root, 'commands/a.md', 'no citation here\n');
+    },
+    expectExit: 1,
+    expectSubstring: 'no citation of `references/foo.md`',
+  },
+  {
+    name: 'references FAIL — cited only from another file under references/',
+    checkId: 'references',
+    build(root) {
+      write(root, 'references/foo.md', 'content\n');
+      write(root, 'references/other.md', 'cross-cite `references/foo.md`\n');
+      write(root, 'commands/a.md', 'no citation here\n');
+    },
+    expectExit: 1,
+    expectSubstring: 'no citation of `references/foo.md`',
+  },
+  {
+    name: 'references PASS — cited only from a file under agents/',
+    checkId: 'references',
+    build(root) {
+      write(root, 'references/foo.md', 'content\n');
+      write(root, 'agents/b.md', 'see `references/foo.md` for details\n');
+      write(root, 'commands/a.md', 'no citation here\n');
+    },
+    expectExit: 0,
+    expectSubstring: 'references: PASS',
+  },
+  {
+    name: 'references UNKNOWN — empty references/ directory',
+    checkId: 'references',
+    build(root) {
+      fs.mkdirSync(path.join(root, 'references'), { recursive: true });
+      write(root, 'commands/a.md', 'nothing to cite\n');
+    },
+    expectExit: 2,
+    expectSubstring: 'empty references/ glob',
+  },
+  {
+    name: 'version-bump FAIL — commands/ touched, version unchanged',
+    checkId: 'version-bump',
+    build(root) {
+      gitInit(root);
+      write(root, '.claude-plugin/plugin.json', '{"version": "1.0.0"}\n');
+      write(root, 'commands/a.md', 'initial\n');
+      gitCommit(root, 'init');
+      write(root, 'commands/a.md', 'changed\n');
+      gitCommit(root, 'change');
+    },
+    expectExit: 1,
+    expectSubstring: 'version unchanged',
+  },
+  {
+    name: 'version-bump FAIL — version differs only by trailing whitespace',
+    checkId: 'version-bump',
+    build(root) {
+      gitInit(root);
+      write(root, '.claude-plugin/plugin.json', '{"version": "1.0.0"}\n');
+      write(root, 'commands/a.md', 'initial\n');
+      gitCommit(root, 'init');
+      write(root, '.claude-plugin/plugin.json', '{"version": "1.0.0 "}\n');
+      write(root, 'commands/a.md', 'changed\n');
+      gitCommit(root, 'change');
+    },
+    expectExit: 1,
+    expectSubstring: 'version unchanged',
+  },
+  {
+    name: 'version-bump PASS — real version bump',
+    checkId: 'version-bump',
+    build(root) {
+      gitInit(root);
+      write(root, '.claude-plugin/plugin.json', '{"version": "1.0.0"}\n');
+      write(root, 'commands/a.md', 'initial\n');
+      gitCommit(root, 'init');
+      write(root, '.claude-plugin/plugin.json', '{"version": "1.1.0"}\n');
+      write(root, 'commands/a.md', 'changed\n');
+      gitCommit(root, 'change');
+    },
+    expectExit: 0,
+    expectSubstring: 'version 1.0.0 → 1.1.0',
+  },
+  {
+    name: 'version-bump PASS — commit touching only docs/ is not applicable',
+    checkId: 'version-bump',
+    build(root) {
+      gitInit(root);
+      write(root, '.claude-plugin/plugin.json', '{"version": "1.0.0"}\n');
+      write(root, 'commands/a.md', 'initial\n');
+      gitCommit(root, 'init');
+      write(root, 'docs/notes.md', 'unrelated\n');
+      gitCommit(root, 'docs change');
+    },
+    expectExit: 0,
+    expectSubstring: 'not applicable',
+  },
+  {
+    name: 'version-bump UNKNOWN — not a git working tree',
+    checkId: 'version-bump',
+    build() {},
+    expectExit: 2,
+    expectSubstring: 'git rev-parse HEAD~1 failed',
+  },
+  {
+    name: 'version-bump UNKNOWN — single-commit repo, HEAD~1 unresolvable',
+    checkId: 'version-bump',
+    build(root) {
+      gitInit(root);
+      write(root, '.claude-plugin/plugin.json', '{"version": "1.0.0"}\n');
+      gitCommit(root, 'init');
+    },
+    expectExit: 2,
+    expectSubstring: 'git rev-parse HEAD~1 failed',
+  },
+  {
+    name: 'any check UNKNOWN — --root with no commands/ directory yields a named record',
+    checkId: 'sentinels',
+    build(root) {
+      fs.mkdirSync(path.join(root, 'agents'), { recursive: true });
+    },
+    expectExit: 2,
+    expectSubstring: 'cannot list directory',
+  },
+];
+
+function main() {
+  let failures = 0;
+  for (const c of CASES) {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ba-invariants-'));
+    try {
+      c.build(root);
+      const { exitCode, stdout } = runChecker(root, c.checkId);
+      const exitOk = exitCode === c.expectExit;
+      const substringOk = stdout.includes(c.expectSubstring);
+      if (exitOk && substringOk) {
+        console.log(`PASS: ${c.name}`);
+      } else {
+        failures++;
+        console.log(`FAIL: ${c.name}`);
+        console.log(`  expected exit ${c.expectExit}, got ${exitCode}`);
+        console.log(`  expected stdout to include: ${c.expectSubstring}`);
+        console.log(`  actual stdout:\n${stdout}`);
+      }
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  }
+  if (failures > 0) {
+    console.error(`${failures}/${CASES.length} selfcheck case(s) failed.`);
+    process.exitCode = 1;
+  } else {
+    console.log(`All ${CASES.length} selfcheck cases passed.`);
+  }
+}
+
+main();


### PR DESCRIPTION
**Risk:** medium — largely size-driven (816 lines across 4 files); no sensitive paths (auth, payments, migrations) or breaking changes touched.

This repo's cross-file conventions — the `[AUTO-SCORE:` sentinel contract between `commands/ba/review-plan.md` and `commands/ba/plan.md`, heredoc sentinel pairing inside fenced blocks, `references/*.md` load-site citations, and `.claude-plugin/plugin.json` version-bump discipline — were enforced by nothing before this change: nothing failed if they drifted. Adds `scripts/check-invariants.mjs` (a stdlib-only, read-only Node checker for these three invariants), `scripts/selfcheck-invariants.mjs` (exercises every check's FAIL/UNKNOWN branch against ephemeral trees so a broken checker can't silently ship green), and a GitHub Actions workflow that runs both on push to `main` and on every PR.

This is the repo's first executable code and first CI job — until now it was pure prose (`commands/`/`agents/`/`references/` markdown plus JSON manifests). The dominant failure mode for this class of tool is a "vacuous green": a check whose subject set silently collapsed to empty still reports success. Every check reports a tri-state PASS/FAIL/UNKNOWN verdict with its subject count and a reason specifically to make that failure mode visible instead of invisible.

No test framework is introduced (see Alternatives below). Verification is running the scripts themselves: `node scripts/check-invariants.mjs` (all three checks PASS against HEAD) and `node scripts/selfcheck-invariants.mjs` (21/21 cases pass, covering every FAIL/UNKNOWN branch of all three checks, including two nested-fence edge cases a code review surfaced and fixed).

The GitHub Actions workflow itself (triggers, fetch depth, job wiring) can't be exercised locally — no local command can trigger a GitHub Actions run. The first real PR opened after this lands is the actual test of the CI wiring; a missing or red check there should be treated as unfinished, not as flaky CI.

**Proof:** _pending — add tests / QA notes / screenshots before merge_

**Alternatives considered:**
- No registry or hardcoded copy of the cross-file-convention lists — that would make the checker a second source of truth for the very lists it checks.
- No committed fixture corpus for the self-check's negative-path cases — ephemeral trees are built under `os.tmpdir()` at run time and removed after, so nothing checked-in can drift out of sync with the checks.
- `fetch-depth: 0` over `2` in CI — on `pull_request`, GitHub checks out an ephemeral merge commit whose parent chain a shallow depth-2 fetch can leave grafted, silently truncating the `HEAD~1` comparison the version-bump check relies on.
