### PR TITLE
fix(review-plan): don't silently cross a plan's stated exclusions

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-workflow",
-  "version": "0.37.0",
+  "version": "0.38.0",
   "description": "Research, brainstorm, plan, execute, review, compound, and propose commands with triage, convention compliance, and knowledge compounding",
   "author": {
     "name": "Bruno Azevedo"

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ This catches issues at plan time — where fixing things is cheap — instead of
 - **Plan-anchored findings** — each finding anchors to a plan **section heading**, a `### U<n>` unit, or a keyed `AC<n>`; anchors that don't resolve in the plan are dropped and counted
 - **Plan-aware framing** — tells each reviewer it's evaluating a proposal, not finished code
 - **Auto-runs in `/ba:plan`** — at the end of planning, a self-suppressing section-scoring pass runs automatically: on a clean plan it stays silent (no widgets, "no weak sections"); on weak sections it surfaces the ledger and asks before dispatching
+- **Scope-boundary anchor** — a remedy that adds to, narrows, or qualifies the plan's own `What We're NOT Doing` section, or whose resolution requires arguing it doesn't cross a stated exclusion, is never auto-applied as an ordinary fix — it routes through the spec-decision resolution (Decide now / Iterate the plan), quoting the exclusion in the plan's own words
 
 ### `/ba:execute [plan]`
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ This catches issues at plan time — where fixing things is cheap — instead of
 - **Plan-anchored findings** — each finding anchors to a plan **section heading**, a `### U<n>` unit, or a keyed `AC<n>`; anchors that don't resolve in the plan are dropped and counted
 - **Plan-aware framing** — tells each reviewer it's evaluating a proposal, not finished code
 - **Auto-runs in `/ba:plan`** — at the end of planning, a self-suppressing section-scoring pass runs automatically: on a clean plan it stays silent (no widgets, "no weak sections"); on weak sections it surfaces the ledger and asks before dispatching
-- **Scope-boundary anchor** — a remedy that adds to, narrows, or qualifies the plan's own `What We're NOT Doing` section, or whose resolution requires arguing it doesn't cross a stated exclusion, is never auto-applied as an ordinary fix — it routes through the spec-decision resolution (Decide now / Iterate the plan), quoting the exclusion in the plan's own words
+- **Scope-boundary anchor** — a remedy that adds to, narrows, or qualifies the plan's own `What We're NOT Doing` section is never auto-applied as an ordinary fix — it routes through the spec-decision resolution (Decide now / Iterate the plan), quoting the exclusion in the plan's own words
 
 ### `/ba:execute [plan]`
 

--- a/commands/ba/review-plan.md
+++ b/commands/ba/review-plan.md
@@ -512,7 +512,7 @@ Use **AskUserQuestion**:
 **Question:** "How would you like to handle the findings?"
 
 **Options:**
-1. **Apply all fixes** — Update the plan with all main-section Must Address + Consider items
+1. **Apply all fixes** — Update the plan with all main-section Must Address + Consider items, except any routed as a scope decision by the Scope-boundary anchor below
 2. **Apply must-address only** — Fix only the blocking items
 3. **Review one by one** — Go through each finding and decide
 4. **Done** — Acknowledge findings, don't modify the plan
@@ -531,9 +531,23 @@ finding that deletes, relocates, or renames them — consistent with the Step 3 
 the merged finding as a **spec decision** if *any* contributor is a spec decision (the stricter, safer
 classification) — route it through the spec-decision resolution below, never write it as an open question.
 
+**Scope-boundary anchor.** The plan's own exclusions section (the `What We're NOT Doing` /
+`scope-boundaries` row in `references/plan-sections.md`, matched by heading text or `id=""` per the
+anchor rule above) bounds what resolution may apply. Two things are a **spec decision** in the sense
+of the classifier below — regardless of bucket, Must Address included: a fix that **adds to, narrows,
+or qualifies that section**; and any finding whose resolution requires **arguing** that its remedy
+does not cross a stated exclusion — that argument *is* the scope-change conversation, so surface it
+rather than writing it into the plan. Disposition these **before** any bulk apply, and name them in
+the "Plan updated" confirmation so a skipped finding is never silently absent. Quote the exclusion in
+the plan's own words; never adjudicate whether it was user-approved or self-minted. Prefer the
+cheapest remedy that resolves the finding in bounds; where none exists, the conflict is itself the
+decision. Classify a merged finding from its contributing bodies, not its summary line. Absent,
+empty, or unfalsifiably vague exclusions do not fire this rule and add no prompt; Suppressed findings
+stay suppressed.
+
 ### Handling "Consider" items
 
-Before writing any "Consider" fix into the plan, classify it:
+Before writing any "Consider" fix — or any fix routed here by the Scope-boundary anchor above — into the plan, classify it:
 
 **Implementation decision** — something the implementer can resolve with full context during execution (e.g., which utility to use, how to structure a helper). Write it into the plan as concrete guidance: a decision already made, not a question left open.
 

--- a/commands/ba/review-plan.md
+++ b/commands/ba/review-plan.md
@@ -533,12 +533,10 @@ classification) — route it through the spec-decision resolution below, never w
 
 **Scope-boundary anchor.** The plan's own exclusions section (the `What We're NOT Doing` /
 `scope-boundaries` row in `references/plan-sections.md`, matched by heading text or `id=""` per the
-anchor rule above) bounds what resolution may apply. Two things are a **spec decision** in the sense
-of the classifier below — regardless of bucket, Must Address included: a fix that **adds to, narrows,
-or qualifies that section**; and any finding whose resolution requires **arguing** that its remedy
-does not cross a stated exclusion — that argument *is* the scope-change conversation, so surface it
-rather than writing it into the plan. Disposition these **before** any bulk apply, and name them in
-the "Plan updated" confirmation so a skipped finding is never silently absent. Quote the exclusion in
+anchor rule above) bounds what resolution may apply. A fix that **adds to, narrows, or qualifies
+that section** is always a **spec decision** in the sense of the classifier below — regardless of
+bucket, Must Address included. Disposition these **before** any bulk apply, and name them in the
+"Plan updated" confirmation so a skipped finding is never silently absent. Quote the exclusion in
 the plan's own words; never adjudicate whether it was user-approved or self-minted. Prefer the
 cheapest remedy that resolves the finding in bounds; where none exists, the conflict is itself the
 decision. Classify a merged finding from its contributing bodies, not its summary line. Absent,

--- a/docs/brainstorms/2026-07-28-review-plan-scope-exclusion-anchor-brainstorm.md
+++ b/docs/brainstorms/2026-07-28-review-plan-scope-exclusion-anchor-brainstorm.md
@@ -1,0 +1,165 @@
+---
+date: 2026-07-28
+topic: review-plan-scope-exclusion-anchor
+status: approved
+triage_level: standard
+tags: [review-plan, scope-exclusions, cluster-review-quality, issue-66]
+---
+
+# Anchor `/ba:review-plan` resolution to the plan's own scope exclusions
+
+## What We're Building
+
+A short scope-anchor rule in `/ba:review-plan` Step 5 (the resolution menu and the one-by-one
+walk) so that resolution reads the reviewed plan's own scope-boundaries section and treats a
+remedy that re-enters a stated exclusion as a **scope-change conversation**, not a fix to apply.
+For the plan author running `/ba:review-plan` — standalone or embedded via `/ba:plan` Step 7's
+auto-score path.
+
+Origin: GitHub issue #66, observed twice while planning #64 (2026-07-27, 2026-07-28). Measured
+effect on the 2026-07-28 run: the plan grew 410 → 567 lines and 5 → 6 units entirely downstream
+of review, and the added unit carries a defensive paragraph arguing against its own plan's
+`## What We're NOT Doing` entry.
+
+## Why This Approach
+
+**The issue's premise needed correcting first.** #66 reports that review-plan "marked
+(Recommended)" the scope-increasing option. It has no such mechanism: `commands/ba/review-plan.md`
+contains one `recommend` hit (`:170`), about the Adjust pick-list default, not findings. Step 5
+(`:510-518`) specifies only a flat four-option menu. The `(Recommended — Apply/Skip/Modify)`
+disposition lives solely in `commands/ba/review.md:849-857`, and its axis is **fix quality**,
+explicitly not scope. The per-finding option triple observed in the #64 run was therefore
+*improvised* — Step 5 says nothing about composing per-finding option sets.
+
+So the defect is not "an existing recommendation rule lacks a scope clause". It is **under-
+specified option composition, whose improvisation drifts toward inflation**.
+
+Considered and rejected:
+
+- **Port review.md's per-finding disposition and add scope as a second axis.** Rejected: adds a
+  mechanism review-plan does not have, grows an already-618-line unconditionally-resident file
+  against the `#59` weight-reduction lane, and creates a new mirror-site pair to keep in sync.
+- **Reviewer-self-tagging** — widen the Step 3 dispatch context (today `Overview + Acceptance
+  Criteria`, `:293`) and have reviewers tag exclusion-crossing remedies themselves. This is what
+  `docs/research/2026-06-07-preexisting-finding-frequency-research.md` recommends over
+  orchestrator-side classification, and it remains the better shape *if* the chosen approach
+  proves too weak. Rejected for now: touches the owned parser contract (`:188-232`) and every
+  reviewer prompt, for a defect that lives in resolution.
+
+## Key Decisions
+
+- **Steering, not a machine-boundary contract.** "Does this remedy cross a stated exclusion?" is
+  a qualitative call, so per `.claude/agent_docs/prompt-authoring.md` it earns a sentence, not a
+  rubric, scoring table, or threshold. The only character-specified part is the *locator* for the
+  exclusions section.
+- **Locate by the owned vocabulary token, sourced not restated.** The heading/`id` pair is a
+  cross-process anchor agreement (`plan.md` emits, `review-plan.md` reads), so it *is* the one
+  character-level part. But review-plan must **point at `references/plan-sections.md:47`** — which
+  already carries both forms in one row (`| What We're NOT Doing | scope-boundaries | … |`) — rather
+  than hardcoding the heading string. Restating it would create an uncited coupling that a future
+  template rename breaks silently, which is the exact failure `review-plan.md:190` warns about for
+  its own parser contract.
+- **The brainstorm-heading variant (`Scope Boundaries`, `references/brainstorm-sections.md:67`) is
+  rationale only.** Given the no-origin-read decision, review-plan never reads a brainstorm — this
+  note must not travel into the shipped prompt text, where it would be authoring residue.
+- **Applies to both Must Address and Consider**, not just Consider. A finding whose only remedy is
+  a scope increase is a scope-change conversation regardless of its bucket.
+- **Menu stays at four options.** No new option, no new stored field on the finding schema — the
+  4-option AskUserQuestion cap and the compute-at-presentation-time rule are both recorded
+  decisions (`docs/brainstorms/2026-06-28-review-accept-all-recommendations-brainstorm.md`).
+- **One site covers both paths.** `/ba:plan` Step 7's auto-score path delegates resolution to
+  review-plan Step 5, so a Step 5 change reaches the embedded path with no second edit.
+- **Prefer the cheapest in-bounds remedy.** In the #64 run, option 3 ("wire `--root`, no self-check
+  unit") resolved the objection at near-zero cost; option 1 added a unit. The rule must bias toward
+  the former and, when no in-bounds remedy exists, present the exclusion conflict *as* the decision
+  rather than burying it in an option description.
+- **Verification gates the merge:** fixture A/B, not argument (see Acceptance Criteria).
+
+## Scope Boundaries
+
+- **No origin read.** #66's filed fix direction asks review-plan to also read the origin's
+  out-of-scope section when `origin:` is present. Dropped deliberately: it reverses the recorded
+  "review-plan is deliberately not given the origin — that is issue #6, separate" decision, pulls
+  #6's deferred surface forward, and would have been **inert on the #64 run that motivated the
+  issue** (a ticket-origin plan has no `origin:`; the field only ever points at a brainstorm and is
+  optional). The in-plan section is always present and format-neutral. *(User decision, surfaced
+  conversationally — not narrowed inside this artifact.)*
+- No change to the reviewer prompts, the Step 3 dispatch context, or the Plan-Anchor & Confidence
+  Grammar parser contract.
+- No change to `/ba:review` (the diff-review sibling). A diff has no stated scope boundary; a plan
+  does. The divergence is deliberate.
+- No new reviewer, agent, or skill. Anything discoverable under `.claude/agents/` becomes permanent
+  never-hide-ledger noise on every run (precedent: commit `73f9276`).
+- No confidence-floor, gate-arithmetic, or Suppressed-bucket changes.
+- No scope-governor state machine (diff-growth multipliers, patch-cycle counters) of the kind
+  `docs/research/2026-07-21-autoreview-skill-vs-ba-review-research.md` describes.
+
+## Acceptance Criteria
+
+- Step 5 resolution names, in its option or finding text, which exclusion a scope-increasing remedy
+  crosses — quoting the plan's own wording — rather than presenting it as an ordinary fix.
+- A finding whose only remedy is a scope increase is routed as a scope-change decision, never
+  auto-applied under "Apply all fixes" or "Apply must-address only".
+- When an in-bounds remedy exists, it is the one preferred; the scope-increasing alternative is
+  never the endorsed default.
+- **The rule is inert when it should be:** a plan with an empty or absent scope-boundaries section
+  produces no added prompt, no added widget, and no behavior change. (Guards the documented
+  dead-gate failure: a first draft of the analogous `/ba:plan` ledger gate surfaced nothing on 2 of
+  3 fixtures because its trigger was coverage-shaped.)
+- Detection works on both `.md` and `.html` plans via the heading text and the `scope-boundaries`
+  `id` respectively.
+- **Fixture A/B per `.claude/agent_docs/prompt-authoring.md` before merge:** 3 fixtures with planted
+  ground truth (a plan with a tempting exclusion plus a finding whose obvious remedy crosses it),
+  ≥2 conditions (current `main` + the proposal), one subagent per cell at the session model, no repo
+  access. Scored **in both directions** — exclusion-crossings correctly named, *and* units/lines/ACs
+  added, the metric that produced the reconciliation ledger's 9/8/8-vs-12/12/13 result. A run in a
+  fresh session; a prompt change cannot be dry-run in the session that wrote it.
+- **Weight budget honoured:** the addition to `commands/ba/review-plan.md` (618 lines, fully resident
+  on every invocation) stays within ~12 added lines. Anything larger belongs in `references/` behind a
+  named load site, per `.claude/agent_docs/prompt-authoring.md`.
+- `README.md`'s `/ba:review-plan` bullet list documents the new resolution behavior. The existing list
+  already describes Step-5-level user-visible facts (`README.md:140`, the Suppressed-bucket rule), so a
+  change to what resolution will and won't auto-apply belongs there too.
+- `.claude-plugin/plugin.json` version bumped.
+
+## Open Questions
+
+_None._
+
+### Resolved Questions
+
+- **Which mechanism, given no recommendation machinery exists?** → Constrain the existing menu with
+  a scope-anchor rule. (Rejected: porting review.md's disposition; reviewer-self-tagging.)
+- **Read the origin's out-of-scope section too?** → No. In-plan section only; see Scope Boundaries.
+- **Fixture A/B or ship-on-dry-run?** → A/B gates the merge. The near-identical gate in `/ba:plan`
+  is on record as having fired on nothing in a first draft, which no static read caught.
+
+## Convention Compliance
+
+`dev-workflow:convention-checker`, 2026-07-28: **0 violations, 4 warnings, 12 aligned.**
+
+Verified aligned: machine-boundary-vs-steering classification correct; **no mirror-site obligation
+fires** — the never-hide-ledger sites (`README.md`, `review.md` Step 2, `review-plan.md` Step 2) govern
+*reviewer selection*, not Step 5 resolution, and `review-plan.md` is reader-only on the U-ID axis and
+grammar-only on the stack-base axis per the CLAUDE.md 2-axis grid; the "one site covers both paths"
+claim confirmed against `plan.md:671,683-684` (Step 7 reads only the verdict sentinel and composes no
+resolution options, so no second edit); artifact path, all five mandatory frontmatter fields, STANDARD
+section set, and no-code rule all satisfied; both cited precedents check out (4-option cap at
+`docs/brainstorms/2026-06-28-review-accept-all-recommendations-brainstorm.md:26,46,77`; the no-origin
+decision at `docs/brainstorms/2026-07-24-plan-requirement-reconciliation-ledger-brainstorm.md:108`,
+which this proposal preserves rather than reverses).
+
+All four warnings resolved into this document: locator sourced from `references/plan-sections.md`
+rather than restated (W2); a ~12-line weight budget and a README bullet added to Acceptance Criteria
+(W3, W1); the brainstorm-heading variant marked rationale-only so it cannot become authoring residue
+in the shipped prompt (W4).
+
+## Next Steps
+→ `/ba:plan` to create implementation plan
+
+**Revised at plan-time** (2026-07-28, both surfaced and approved — see
+`docs/plans/2026-07-28-fix-review-plan-scope-exclusion-anchor-plan.md` Sources for the reasoning):
+the trigger shape above ("when a finding's remedy re-enters a stated exclusion") is **superseded** —
+it is dead on the #64 case, since that plan's exclusion bullet was edited to pre-justify the remedy;
+and the A/B's "fresh session" requirement was imprecise (inline text to subagents runs in-session).
+The plan is authoritative on both.

--- a/docs/plans/2026-07-28-fix-review-plan-scope-exclusion-anchor-plan.md
+++ b/docs/plans/2026-07-28-fix-review-plan-scope-exclusion-anchor-plan.md
@@ -1,0 +1,405 @@
+---
+title: Anchor /ba:review-plan resolution to the plan's own scope exclusions
+type: fix
+plan_schema: 2
+status: active  # human-authored only — /ba:execute ignores this for control flow (including status: completed); progress is git-derived
+date: 2026-07-28
+origin: docs/brainstorms/2026-07-28-review-plan-scope-exclusion-anchor-brainstorm.md
+detail_level: standard
+tags: [review-plan, scope-exclusions, cluster-review-quality, issue-66, prompt-text]
+---
+
+# Anchor `/ba:review-plan` Resolution to the Plan's Own Scope Exclusions
+
+## Overview
+
+`/ba:review-plan` Step 5 resolves review findings with no awareness of what the reviewed plan
+explicitly put out of scope, so a reviewer's remedy can grow the plan past its own stated bounds.
+This adds a short steering rule that makes the plan's exclusions section a bound on what resolution
+may apply, and routes a scope-increasing remedy through the spec-decision path that already exists
+rather than applying it as an ordinary fix. Fixes GitHub issue #66.
+
+## Current State
+
+- `commands/ba/review-plan.md` is 618 lines, fully resident on every invocation. Step 5 spans
+  `:493-562`.
+- **The menu is static and scope-blind** — four options at `:515-518`; the Suppressed carve-out at
+  `:520-523`; merged-finding classification at `:530-532`; the implementation-vs-spec-decision
+  classifier at `:534-546`.
+- **No per-finding recommendation mechanism exists.** The file's only `recommend` hit is `:170`
+  (the Adjust pick-list default). `(Recommended — Apply/Skip/Modify)` lives solely in
+  `commands/ba/review.md:849-857`, on a **fix-quality** axis that never considers scope. The
+  per-finding option triple observed in the #64 run was improvised, not specified.
+- **A scope classifier already exists but is unanchored.** `:540` defines a spec decision as
+  something affecting "acceptance criteria, user-facing behaviour, **scope**, or … stakeholder
+  input", with a two-option resolution at `:542-545`. It never tells the model to read the plan's
+  exclusions section — which is why #64 slipped past a classifier that was already there. It is
+  also **Consider-only** (`:536` opens "Before writing any \"Consider\" fix"), so Must Address
+  never reaches it.
+- **The locator is already an owned row.** `references/plan-sections.md:47` carries both forms in
+  one line: `| What We're NOT Doing | scope-boundaries | Explicit scope exclusions |`. The anchor
+  matching rule at `review-plan.md:208-211` already resolves on normalized heading text **or** the
+  `id=""` value, and treats struck anchors as non-resolving.
+- **How #64 actually failed.** The plan's exclusion bullet was *edited to pre-justify the remedy*:
+  `docs/plans/2026-07-28-feat-structural-invariant-checks-plan.md:91-95` now reads "…the
+  self-check's negative-path cases are built in `os.tmpdir()` at run time and deleted after —
+  nothing is checked in… That is the distinction from the rejected 8-fixture corpus." Resolution
+  negotiated with the boundary and wrote the negotiation into it. Measured cost: 410→567 lines,
+  5→6 units.
+- `/ba:plan` Step 7 (`plan.md:665-690`) delegates resolution to this same Step 5 — one edit site
+  covers both paths. Confirmed at `plan.md:671` ("review-plan **owns** every widget on the auto
+  path") and `:683-684`.
+
+## Acceptance Criteria
+
+- AC1: A remedy that crosses a stated exclusion is classified a **spec decision regardless of
+  bucket** — Must Address as well as Consider — and resolved through the existing pair at `:542-545`.
+- AC2: A fix that adds to, narrows, or qualifies the plan's scope-boundaries section is never an
+  ordinary applied fix.
+- AC3: When resolution requires *arguing* that a remedy does not cross an exclusion, that argument
+  is surfaced as the scope-change conversation, not written into the plan.
+- AC4: Under "Apply all fixes" and "Apply must-address only" a scope-crossing finding is
+  dispositioned before the bulk apply and named in the `:548` confirmation — never silently skipped.
+- AC5: The rule quotes the exclusion in the plan's own words and never adjudicates whether it was
+  user-approved or self-minted.
+- AC6: Where an in-bounds remedy exists it is the preferred one; the scope-increasing alternative is
+  never the endorsed default. Where none exists, the conflict itself is the decision.
+- AC7: The rule is **inert** when the exclusions section is absent, empty, or too vague for any
+  remedy to be objectively said to cross it — no added prompt, no added widget, no behavior change.
+- AC8: Detection works on `.md` (heading text) and `.html` (`id="scope-boundaries"`) via either
+  signal, tolerates prose-only sections with no bullets, and does not constrain from a struck
+  exclusion.
+- AC9: A Suppressed finding is never resurrected by this rule — the `:520-523` carve-out wins.
+- AC10: A merged finding is classified from its **contributing bodies**, not the merged summary line
+  rendered per `:484`.
+- AC11: On the `--auto` path the rule is live — Step 5 is reachable only via the weak branch, where
+  widgets are already review-plan's, so the inertness criterion must not be over-read into
+  suppressing the rule on the auto path. An "Iterate the plan" resolution surfaces the blocker in the
+  resolution conversation itself. *(Reworded during review: the original required the blocker to be
+  visible at `plan.md`'s handoff menu, which no existing channel can deliver — Step 5's exit threads
+  control only, and the auto-invoke contract's three sentinels cannot encode it. Carrying blocked
+  state back to Step 7 would extend that contract, and this plan classes the gap as pre-existing and
+  out of scope. The cheapest in-bounds criterion is the one stated here.)*
+- AC12: The inserted block is ≤15 lines, plus one clause on option 1 at `:515` and one clause on
+  `:536`. *(Raised from ≤12 during review to absorb AC4's ordering-and-confirmation requirement;
+  15 lines in a 618-line file leaves the resident-weight judgment unchanged.)*
+- AC13: A fixture A/B is run and scored before merge: 5 fixtures × 2 conditions, scored in both
+  directions, with planted ground truth recorded in the research doc and the scored result also in
+  the commit body.
+- AC14: `README.md`'s `/ba:review-plan` bullet list documents the new resolution behavior, and
+  `.claude-plugin/plugin.json` is bumped from `0.37.0`.
+
+## What We're NOT Doing
+
+Carried from the brainstorm (`:76-95`), unchanged:
+
+- **No origin read.** #66's filed direction asks review-plan to also read the origin's out-of-scope
+  section. Dropped by user decision: it reverses the recorded "review-plan is deliberately not given
+  the origin — that is issue #6, separate" boundary, pulls #6's deferred surface forward, and would
+  have been **inert on the #64 run that motivated the issue** (a ticket-origin plan has no `origin:`;
+  the field only ever points at a brainstorm and is optional).
+- No change to reviewer prompts, the Step 3 dispatch context (`:293`), or the Plan-Anchor &
+  Confidence Grammar parser contract (`:188-232`).
+- No change to `/ba:review`. A diff has no stated scope boundary; a plan does. The divergence is
+  deliberate.
+- No new reviewer, agent, or skill — anything discoverable under `.claude/agents/` becomes permanent
+  never-hide-ledger noise on every run (precedent: commit `73f9276`).
+- No confidence-floor, gate-arithmetic, or Suppressed-bucket changes.
+- No scope-governor state machine (diff-growth multipliers, patch-cycle counters).
+- **No committed fixtures.** The A/B fixtures live in the session scratchpad; their planted ground
+  truth is reproduced in the research doc instead. `git ls-files | grep -i fixture` is empty — this
+  repo has never committed a corpus.
+- No new menu option and no new field on the finding schema — the four-option cap and the
+  compute-at-presentation-time rule are recorded decisions
+  (`docs/brainstorms/2026-06-28-review-accept-all-recommendations-brainstorm.md:26,46,77`).
+
+## Proposed Solution
+
+Extend the **existing spec-decision class** rather than building a parallel mechanism. `:540`
+already routes anything affecting scope to a spec decision; it simply lacks an anchor and is
+Consider-only. So the change supplies the anchor, lifts the bucket restriction, and inherits
+`:542-545` for resolution and `:530-532` for merges at zero added machinery.
+
+**The trigger shape is the load-bearing decision.** A literal "does this remedy re-enter a stated
+exclusion?" test — the brainstorm's original wording — is dead on the case that motivated the issue:
+the excluded thing was a *committed* corpus and the remedy was ephemeral `mktemp`, so the honest
+answer is "no". Worse, asking it of the same context that wants the fix reliably returns "no", which
+is verbatim what #64's plan now argues at `:91-95`. Two triggers that do fire replace it (approved
+at plan-time — see Sources):
+
+1. **A fix that edits the boundary section is always a scope-change decision.** Objectively
+   detectable, immune to negotiation, and would have caught #64 on its own.
+2. **The argument is the signal.** If resolving a finding requires arguing the remedy does not cross
+   an exclusion, that argument *is* the conversation.
+
+Placement: one block immediately after `:532`, which already forward-references "the spec-decision
+resolution below" — so the forward reference follows an established shape rather than inventing one.
+The block presents its two triggers as cases of `:540`'s existing spec-decision test rather than as a
+second, separately-named test, and `:536`'s Consider-only framing is widened in the same change so the
+routing target does not contradict the routing rule.
+
+## Technical Considerations
+
+- **Steering, not a machine-boundary contract.** "Does this remedy cross a stated exclusion?" is a
+  qualitative call, so per `.claude/agent_docs/prompt-authoring.md:9-20` it earns prose, not a rubric,
+  scoring table, or threshold arithmetic. The single cross-process agreement — the locator — is
+  specified by *citation* to `references/plan-sections.md:47` rather than restated, so a template
+  rename cannot silently break detection.
+- **Weight.** ≤15 lines added to a 618-line fully-resident file; no `references/` offload needed at
+  that size. Keep the brainstorm-heading variant (`Scope Boundaries`) out of shipped text — with no
+  origin read, review-plan never reads a brainstorm, so it would be authoring residue.
+- **The behavioral claim lives in U2, not in U1's `Verify:`.** A grep over prose the same change just
+  wrote confirms authorship, not behavior (`prompt-authoring.md:61-63`). U1's `Verify:` asserts the
+  three edit sites are coupled; U2 is the evidence.
+
+## System-Wide Impact
+
+- **Interaction graph.** Step 5 is entered from two callers: a manual `/ba:review-plan` run, and
+  `/ba:plan` Step 7's `--auto` invocation. One edit reaches both. Within Step 5 the rule composes
+  with three existing mechanisms: the Suppressed carve-out (`:520-523`, which **dominates**), the
+  merged-finding stricter classification (`:530-532`, which the rule inherits by being a spec-decision
+  subtype), and the spec-decision resolution pair (`:542-545`, which it reuses).
+- **Error propagation.** The rule's failure mode is not an exception but silence — a dead clause that
+  never fires. That is why AC7 asserts inertness *and* U2 tests a no-section fixture: the analogous
+  `/ba:plan` ledger gate's first draft surfaced nothing on 2 of 3 fixtures because its trigger was
+  coverage-shaped.
+- **State lifecycle risk.** The pre-existing "Iterate the plan" resolution (`:544`) carries no
+  blocked state back to `plan.md` Step 7, whose handoff menu offers "Start implementation" first
+  (`plan.md:697`). This rule materially raises that path's firing rate on the auto path — precisely
+  where the plan just minted its own exclusions. **No existing channel can carry that blocked state**:
+  Step 5's exit threads control only, and the auto-invoke contract's three sentinels cannot encode it.
+  Closing the gap means extending that contract, which this plan holds out of scope, so AC11 was
+  reworded during review to the in-bounds criterion the mechanism can actually meet. The residual risk
+  is real and stated: a user who has just judged the plan blocked is still offered "Start
+  implementation" first at the handoff menu.
+- **No mirror-site obligation fires.** `review-plan.md` is reader-only on the U-ID axis and
+  grammar-only on the stack-base axis per the CLAUDE.md 2-axis grid; the never-hide-ledger sites
+  govern reviewer *selection*, not resolution. `README.md` is required separately (see U3).
+
+## Implementation Approach
+
+### Changes Required
+
+**File**: `commands/ba/review-plan.md`
+
+#### U1 — Scope-boundary anchor in Step 5
+
+**Three coupled edit sites.** Insert one block immediately after the merged-finding classification
+(`:530-532`, ending at `:532`), before the `### Handling "Consider" items` subsection at `:534`; amend
+option 1's text at `:515`; and amend `:536` so the classifier it introduces is no longer
+Consider-only. All three land together — the block routes findings into a subsection that, unamended,
+declares itself out of scope for them.
+
+**Code-shape decision:** the shipped artifact *is* the wording, and U2's A/B scores this exact text —
+re-deriving it from a prose description would invalidate the evidence.
+
+Site 1 — the block, after `:532`:
+
+```markdown
+**Scope-boundary anchor.** The plan's own exclusions section (the `What We're NOT Doing` /
+`scope-boundaries` row in `references/plan-sections.md`, matched by heading text or `id=""` per the
+anchor rule above) bounds what resolution may apply. Two things are a **spec decision** in the sense
+of the classifier below — regardless of bucket, Must Address included: a fix that **adds to, narrows,
+or qualifies that section**; and any finding whose resolution requires **arguing** that its remedy
+does not cross a stated exclusion — that argument *is* the scope-change conversation, so surface it
+rather than writing it into the plan. Disposition these **before** any bulk apply, and name them in
+the "Plan updated" confirmation so a skipped finding is never silently absent. Quote the exclusion in
+the plan's own words; never adjudicate whether it was user-approved or self-minted. Prefer the
+cheapest remedy that resolves the finding in bounds; where none exists, the conflict is itself the
+decision. Classify a merged finding from its contributing bodies, not its summary line. Absent,
+empty, or unfalsifiably vague exclusions do not fire this rule and add no prompt; Suppressed findings
+stay suppressed.
+```
+
+Site 2 — at `:515`, append the exception clause (the block sits **below** this line):
+
+```markdown
+1. **Apply all fixes** — Update the plan with all main-section Must Address + Consider items, except any routed as a scope decision by the Scope-boundary anchor below
+```
+
+Site 3 — at `:536`, widen the classifier's own scope so a Must Address finding routed by the block
+actually reaches it:
+
+```markdown
+Before writing any "Consider" fix — or any fix routed here by the Scope-boundary anchor above — into the plan, classify it:
+```
+
+Test scenarios:
+- A finding whose fix edits `## What We're NOT Doing` is routed to the spec-decision pair, not
+  applied (Covers AC2)
+- A Must Address finding crossing an exclusion routes as a spec decision (Covers AC1)
+- "Apply all fixes" on a set containing one scope-crossing finding dispositions it first and names it
+  in the confirmation (Covers AC4)
+- An `.html` plan whose `scope-boundaries` `id` is present but heading text differs still resolves
+  (Covers AC8)
+- A plan with a prose-only exclusions section and no bullets still resolves (Covers AC8)
+- A plan with no exclusions section produces no added prompt or widget (Covers AC7)
+- A suppressed scope-crossing finding stays suppressed (Covers AC9)
+- A merged finding with one scope-crossing contributor at Consider and one in-bounds contributor at
+  Must Address classifies as a scope decision from the contributor bodies, not from the merged
+  summary line rendered per `:484` (Covers AC10)
+- When the rule fires, the surfaced text **quotes** the exclusion verbatim from the plan and makes no
+  claim about whether it was user-approved or self-minted (Covers AC5)
+- A Must Address finding routed by the block reaches the classifier at `:536` without hitting its
+  Consider-only framing (Covers AC1)
+- Inserted block is ≤15 lines (Covers AC12)
+
+Verify: `grep -q 'Scope-boundary anchor' commands/ba/review-plan.md && grep -q 'plan-sections.md' commands/ba/review-plan.md && grep -q 'scope-boundaries' commands/ba/review-plan.md && grep -q 'routed as a scope decision by the Scope-boundary anchor below' commands/ba/review-plan.md && grep -q 'routed here by the Scope-boundary anchor above' commands/ba/review-plan.md && grep -q 'requires \*\*arguing\*\*' commands/ba/review-plan.md && grep -q 'before\*\* any bulk apply' commands/ba/review-plan.md` — seven conjuncts spanning all three edit sites plus both triggers and the ordering clause. Fails on a partial edit, on an edit that ships only the boundary-edit trigger, and on one that drops the bulk-apply ordering requirement. Behavioral evidence lives in U2, not here — a grep over prose this change just wrote confirms authorship, not behavior.
+
+---
+
+**File**: `docs/research/2026-07-28-review-plan-scope-anchor-ab-research.md`
+
+#### U2 — Fixture A/B, scored before merge
+
+Five fixtures × two conditions = ten subagent cells, one subagent per cell, **no repo access**, the
+candidate Step 5 text passed **inline** (this is what makes the method valid in the session that
+wrote the change — the subagents never load the repo's copy). Conditions: `main`'s Step 5 text vs
+Step 5 with U1's block.
+
+| Fixture | Planted ground truth | Measures |
+|---|---|---|
+| F1 | Exclusion whose literal wording the remedy evades — the #64 shape (excluded "committed corpus", remedy uses ephemeral temp dirs) | Does trigger 2 fire where a literal test would not |
+| F2 | A finding whose fix edits the exclusions section to justify itself | Does trigger 1 fire |
+| F3 | Exclusion crossed plainly, with a cheaper in-bounds remedy available | AC6 — is the in-bounds remedy preferred |
+| F4 | **Control**: real, tempting exclusions section; all findings clearly in-bounds | False-positive rate — the rule's main cost |
+| F5 | **No exclusions section at all** | AC7 inertness — the dead-gate guard |
+
+Score in both directions per `.claude/agent_docs/prompt-authoring.md:73-93`: crossings surfaced, and
+units/ACs/lines added per cell (the metric that produced the reconciliation ledger's 9/8/8-vs-12/12/13
+result), plus F4 misfires and F5 added prompts. Record each fixture's planted ground truth in the
+research doc so the run is reproducible without committed fixtures. Copy the scored result into the
+commit body, matching commit `247a863`.
+
+Record every cell as a `main:` / `proposal:` line pair per fixture, so a partially-run A/B is visible
+as missing pairs rather than narrated as complete.
+
+**Declared pass/fail rule — fixed before the run, not after.** The proposal passes only if all three
+hold; anything else sends U1 back for rewording rather than being reported as a qualified win:
+- **Fires:** F1 and F2 both surface the scope conversation under the proposal and neither does under
+  `main`. (F1 and F2 are the two triggers; one firing is not enough.)
+- **Doesn't misfire:** F4 surfaces **zero** additional findings framed as scope conversations relative
+  to `main`. Any nonzero count is a fail, not a judgment call — this replaces the unfalsifiable "no
+  material increase".
+- **Stays inert:** F5 adds **zero** prompts under the proposal.
+
+F3 is scored and reported but does not gate: remedy *preference* (AC6) is a softer signal than firing
+and inertness, and gating on it would let a taste call block a fix whose triggers work.
+
+**Known limitation to record in the doc, not fix:** one control fixture is weak evidence against the
+misfire risk. A second control variant was proposed during review and set aside — it grows the A/B
+past the 5 approved fixtures, and the in-bounds alternative is to state this limit plainly.
+
+Test scenarios:
+- F1/F2 surface the scope conversation under the proposal and not under `main` (Covers AC3)
+- F4 surfaces zero additional scope-framed findings (Covers AC7)
+- F5 shows zero added prompts under the proposal (Covers AC7)
+- Each of F1–F5 carries both a `main:` and a `proposal:` scored line (Covers AC13)
+- The pass/fail rule is stated in the doc before the results section (Covers AC13)
+
+Verify: `f=docs/research/2026-07-28-review-plan-scope-anchor-ab-research.md; test -f "$f" && for k in F1 F2 F3 F4 F5; do grep -q "$k" "$f" || exit 1; done && [ "$(grep -c 'main:' "$f")" -ge 5 ] && [ "$(grep -c 'proposal:' "$f")" -ge 5 ] && grep -qi 'control' "$f" && grep -qiE 'pass/fail|passes only if' "$f"` — five independent fixture conjuncts (no ordered chain, no alternation), ≥5 scored pairs in each condition so a partial run fails, plus the control and the pre-declared threshold.
+
+---
+
+**Files**: `README.md`, `.claude-plugin/plugin.json`
+
+#### U3 — Mirror updates
+
+Add a `/ba:review-plan` bullet to `README.md` describing the new resolution behavior, alongside the
+existing Step-5-level bullet at `README.md:140` (the Suppressed-bucket rule) — same class of
+user-visible fact, and required by the "update README whenever commands are changed" convention.
+Bump `.claude-plugin/plugin.json` from `0.37.0`; this is now CI-enforced by the invariant checker
+shipped in `9fab557`.
+
+Test scenarios:
+- README describes that a scope-increasing remedy is not auto-applied (Covers AC14)
+- The invariant checker's version-bump check passes (Covers AC14)
+
+Verify: `grep -qi 'scope' README.md && grep -q 'review-plan' README.md && ! grep -q '"version": "0.37.0"' .claude-plugin/plugin.json`
+
+## Dependencies & Risks
+
+- **U2 gates the merge, U1 is its subject.** U1 must land in the working tree before U2 runs; U2's
+  result can send U1 back for rewording. Sequence U1 → U2 → U3.
+- **Primary risk: dead text.** The rule fires on nothing, exactly as the analogous `/ba:plan` gate's
+  first draft did on 2 of 3 fixtures. Mitigated by F1/F2 (which encode the #64 shape) and by choosing
+  triggers that are objectively detectable rather than self-queried.
+- **Secondary risk: misfire.** Every "add a test scenario" finding gets framed as a scope
+  conversation because some adjacent exclusion exists. Mitigated by F4 and by the
+  unfalsifiably-vague default (in doubt → ordinary fix).
+- **Live-harness confirmation is post-merge.** A running session executes the command body it loaded
+  at start, so the shipped behavior can only be confirmed in a later session. The A/B is the
+  pre-merge evidence; the first real `/ba:review-plan` run is the confirmation.
+- Pre-existing, inherited not introduced: Step 5's "Iterate the plan" has no blocked-state channel
+  back to `plan.md` Step 7. AC11 was reworded during review to stop asserting a guarantee no mechanism
+  provides; the residual risk is recorded in System-Wide Impact rather than closed here.
+- **U3's `Verify:` is knowingly weak.** Two of its three conjuncts pass at HEAD (README already
+  carries 7 "scope" hits and 3 "review-plan" hits), so only the version-bump negation has signal. The
+  finding was left unapplied under "Apply must-address only" — a run that bumps the version but never
+  adds the README bullet will pass U3's check. Tighten to a behavior-specific phrase if U3 is revisited.
+
+## Sources & References
+
+### Origin
+- Brainstorm: `docs/brainstorms/2026-07-28-review-plan-scope-exclusion-anchor-brainstorm.md` — carried
+  forward: constrain the existing menu rather than porting review.md's disposition; locator sourced
+  not restated; no origin read (user decision); steering not a rubric; A/B gates the merge.
+
+**Two brainstorm decisions revised at plan-time, both surfaced and approved:**
+1. **Trigger shape.** The brainstorm's "when a finding's remedy re-enters a stated exclusion" is
+   replaced by the boundary-edit and argument-is-the-signal triggers — the original is dead on the
+   #64 case, per `docs/plans/2026-07-28-feat-structural-invariant-checks-plan.md:91-95`.
+2. **A/B framing.** The brainstorm's "fresh session" requirement was imprecise. The A/B passes
+   candidate text inline to subagents with no repo access, so it runs in-session; a fresh session is
+   needed only for the post-merge live-harness confirmation. Fixture count also grew 3 → 5 (control +
+   no-section).
+
+### Internal References
+- Target: `commands/ba/review-plan.md:493-562` (Step 5), `:515`, `:520-523`, `:530-532`, `:540`,
+  `:542-545`, `:548`, `:208-211` (anchor matching), `:484` (merged template)
+- Locator contract: `references/plan-sections.md:47`
+- Precedent (working analogue): `commands/ba/plan.md:496-559` (Step 4.6), `:563-615` (Step 5 gate)
+- Auto path: `commands/ba/plan.md:665-690`, esp. `:671`, `:683-684`
+- Non-precedent: `commands/ba/review.md:849-857` (fix-quality disposition, scope-blind)
+- Method: `.claude/agent_docs/prompt-authoring.md:9-20` (trust gradient), `:73-93` (fixture A/B)
+- Evidence precedent: commit `247a863` (A/B result in commit body; scope-inflation damping metric)
+- Issue: GitHub #66
+
+## Convention Compliance
+
+- [x] Prompt change classified machine-boundary vs steering; only the locator is character-specified,
+  by citation — aligned
+- [x] No mirror-site obligation on the U-ID or stack-base axis; never-hide-ledger sites untouched —
+  aligned (verified against the CLAUDE.md 2-axis grid)
+- [x] README + `plugin.json` bump included (U3) — aligned
+- [x] `plan_schema: 2`, keyed `AC<n>`, `### U<n> — <title>` anchors, artifact naming — aligned
+- [x] Literal code only under a `**Code-shape decision:**` label (U1) — aligned; justified because the
+  wording is the deliverable and the A/B scores that exact text
+- [x] Planning command writes no production code — aligned
+- [x] Brainstorm AC "inert when it should be" restored as AC7 + fixture F5 after being flagged as a
+  dropped requirement — resolved, user chose to comply
+- [x] Two brainstorm revisions (trigger shape, A/B framing) surfaced conversationally and approved,
+  recorded in Sources rather than settled silently — aligned
+- [x] `docs/research/` is an accepted home for A/B evidence (`prompt-authoring.md:92-93`), with the
+  scored result also in the commit body per `247a863` — aligned
+- [x] Fixtures uncommitted, ground truth recorded in the research doc — aligned with actual practice
+  (`git ls-files | grep -i fixture` is empty)
+
+**Review round (`/ba:review-plan --auto`, 4 reviewers, 23 raw → 12 findings).** Resolution: *Apply
+must-address only.* Applied — U2's `Verify:` regex (alternation made it pass on `F5` alone; replaced
+with five independent conjuncts plus paired `main:`/`proposal:` counts, both **tested**); a declared
+pass/fail rule for the A/B replacing the unfalsifiable "no material increase"; U1's `above` → `below`
+inversion; a **third edit site** at `:536` so a Must Address finding actually reaches the classifier
+the block routes it to; the two triggers framed as cases of `:540` rather than a parallel test; the
+bulk-apply ordering and confirmation-naming requirement AC4 needs; scenarios for AC5 and AC10; and a
+7-conjunct `Verify:` (**tested**: fails at HEAD, fails when trigger 2 is dropped).
+
+Two recommended remedies **crossed this plan's own `## What We're NOT Doing`** and were resolved with
+the cheapest in-bounds alternative instead — the behavior this plan exists to add, applied to itself:
+- AC11's "add a fourth sentinel value" would extend the auto-invoke contract, a gap this plan holds
+  out of scope. **Reworded AC11** to what the mechanism can deliver; residual risk recorded.
+- "Add a second control fixture" grows the A/B past the 5 approved. **Recorded the single-control
+  limitation** in U2 instead.
+
+Left unapplied by the chosen resolution: U3's README `Verify:` false-green (Consider — 2 of 3
+conjuncts pass at HEAD, **verified**; recorded in Dependencies & Risks) and 5 suppressed findings.

--- a/docs/plans/2026-07-28-fix-review-plan-scope-exclusion-anchor-plan.md
+++ b/docs/plans/2026-07-28-fix-review-plan-scope-exclusion-anchor-plan.md
@@ -244,7 +244,7 @@ Test scenarios:
   Consider-only framing (Covers AC1)
 - Inserted block is ≤15 lines (Covers AC12)
 
-Verify: `grep -q 'Scope-boundary anchor' commands/ba/review-plan.md && grep -q 'plan-sections.md' commands/ba/review-plan.md && grep -q 'scope-boundaries' commands/ba/review-plan.md && grep -q 'routed as a scope decision by the Scope-boundary anchor below' commands/ba/review-plan.md && grep -q 'routed here by the Scope-boundary anchor above' commands/ba/review-plan.md && grep -q 'requires \*\*arguing\*\*' commands/ba/review-plan.md && grep -q 'before\*\* any bulk apply' commands/ba/review-plan.md` — seven conjuncts spanning all three edit sites plus both triggers and the ordering clause. Fails on a partial edit, on an edit that ships only the boundary-edit trigger, and on one that drops the bulk-apply ordering requirement. Behavioral evidence lives in U2, not here — a grep over prose this change just wrote confirms authorship, not behavior.
+Verify: `grep -q 'Scope-boundary anchor' commands/ba/review-plan.md && grep -q 'plan-sections.md' commands/ba/review-plan.md && grep -q 'scope-boundaries' commands/ba/review-plan.md && grep -q 'routed as a scope decision by the Scope-boundary anchor below' commands/ba/review-plan.md && grep -q 'routed here by the Scope-boundary anchor above' commands/ba/review-plan.md && grep -q 'before\*\* any bulk apply' commands/ba/review-plan.md` — six conjuncts spanning all three edit sites plus the boundary-edit trigger and the ordering clause. **Post-ship narrowing (see closing note below): the seventh conjunct, `requires **arguing**`, was dropped along with trigger 2 itself** — the A/B in U2 could not show it fires beyond what pre-existing mechanisms already caught, so it was removed as unproven prompt weight rather than shipped on the strength of the objection alone. Fails on a partial edit or on one that drops the bulk-apply ordering requirement. Behavioral evidence lives in U2, not here — a grep over prose this change just wrote confirms authorship, not behavior.
 
 ---
 
@@ -403,3 +403,15 @@ the cheapest in-bounds alternative instead — the behavior this plan exists to 
 
 Left unapplied by the chosen resolution: U3's README `Verify:` false-green (Consider — 2 of 3
 conjuncts pass at HEAD, **verified**; recorded in Dependencies & Risks) and 5 suppressed findings.
+
+**Post-ship narrowing (after PR #68 was opened).** U2's A/B (`docs/research/2026-07-28-review-plan-scope-anchor-ab-research.md`)
+could not demonstrate trigger 2 ("resolution requires **arguing** the remedy doesn't cross a stated
+exclusion") fires in any case that `main`'s pre-existing mechanisms (the `:540` generic spec-decision
+clause, or general escalation habit) didn't already catch, across three fixture attempts. Surfaced to
+the user as a scope decision rather than resolved unilaterally; the user chose to strip trigger 2 and
+ship only trigger 1 (editing the exclusion section — the mechanically-verified case that matches the
+actual incident this plan fixes), on the grounds that unproven prompt weight has a real cost per
+`.claude/agent_docs/prompt-authoring.md`. **AC3 is dropped** (it existed solely to cover trigger 2).
+**AC1 is narrowed**: "a remedy that crosses a stated exclusion" now means specifically "a remedy that
+edits/narrows/qualifies the exclusion section," not the broader "requires arguing" case. U1's `Verify:`
+and README bullet were both amended to match; U2's research doc stands as the record of why.

--- a/docs/research/2026-07-28-review-plan-scope-anchor-ab-research.md
+++ b/docs/research/2026-07-28-review-plan-scope-anchor-ab-research.md
@@ -149,3 +149,11 @@ user, not something to resolve unilaterally inside this document.
   than the bare Step 5 text would produce standalone.
 - n=1 per fixture/condition cell (n=3 for F1 after retries) — no statistical power, consistent with the
   fixture-A/B method's "roughly ten minutes of evidence" framing rather than a large-sample claim.
+
+## Outcome
+
+Surfaced to the user post-ship (PR #68 already open) as a scope decision rather than resolved here:
+trigger 2 showed no evidence of firing beyond `main`'s pre-existing mechanisms in any fixture tried.
+The user chose to strip trigger 2 from the shipped rule, keeping only trigger 1 (edits the exclusion
+section) — the mechanically-verified case that matches the actual incident. See the plan's closing
+"Post-ship narrowing" note for the resulting AC1/AC3 changes.

--- a/docs/research/2026-07-28-review-plan-scope-anchor-ab-research.md
+++ b/docs/research/2026-07-28-review-plan-scope-anchor-ab-research.md
@@ -1,0 +1,151 @@
+---
+title: Fixture A/B — Scope-boundary anchor in /ba:review-plan Step 5
+type: research
+date: 2026-07-28
+plan: docs/plans/2026-07-28-fix-review-plan-scope-exclusion-anchor-plan.md
+---
+
+# Fixture A/B — Scope-boundary Anchor (U2)
+
+Method: `.claude/agent_docs/prompt-authoring.md:73-93`. 5 fixtures × 2 conditions, one subagent per
+cell, candidate text passed inline, no repo access instructed. Conditions: `main`'s Step 5 text
+(commit `dffea0e`) vs. Step 5 with U1's Scope-boundary anchor block.
+
+**Declared pass/fail rule (fixed before the run):**
+- **Fires:** F1 and F2 both surface the scope conversation under the proposal and neither does under `main`.
+- **Doesn't misfire:** F4 surfaces zero additional findings framed as scope conversations relative to `main`.
+- **Stays inert:** F5 adds zero prompts under the proposal.
+
+## Discovered confound (read this before the scores below)
+
+The subagents were instructed "no repo access, base your answer purely on the text provided" — but
+they still inherit the calling user's global `CLAUDE.md` as part of their environment, which is
+outside the harness's "no repo access" guarantee. That file contains a standing rule: *"Scope
+reductions escalate — always... overriding a sub-agent/tool that flagged an open decision must be
+surfaced to me conversationally."* Several `main`-condition cells quote this rule verbatim as their
+reason for surfacing a scope conversation — i.e., `main` sometimes produces the exact behavior U1 is
+supposed to add, but via a channel U1 has nothing to do with.
+
+A second, independent confound: `main`'s pre-existing `:540` classifier already says a spec decision is
+"something that affects acceptance criteria, user-facing behaviour, **scope**, or requires stakeholder
+input." When a fixture's finding is worded explicitly enough about scope (F2's finding literally
+proposes editing the exclusion bullet), a capable model reasoning directly over `:540` catches it
+without needing U1's anchor at all — this is consistent with the plan's own Current State analysis
+("a scope classifier already exists but is unanchored") but means a fixture has to isolate the specific
+failure U1 targets (a plan's *own* exclusion, read and quoted) rather than "scope" in the generic
+sense `:540` already covers.
+
+Net effect: F1 was run three times with successively tighter wording, chasing a version where `main`
+plausibly misses it and `proposal` plausibly catches it. All three attempts converged on **both
+conditions agreeing** (either both miss it, when the exclusion's own wording already permits the
+remedy; or both catch it, when the crossing is unambiguous enough that CLAUDE.md's escalation rule and
+`main`'s generic scope wording both fire). F2 shows the same pattern on the first run. This is reported
+as data, not smoothed over — see Verdict below.
+
+## Scored results
+
+### F1 — Exclusion whose wording the remedy evades (the #64 shape)
+
+Three variants were run; the exclusion wording was tightened each time in an attempt to isolate a
+crossing that requires *arguing* rather than one a literal reading already settles.
+
+| Variant | Exclusion wording | main: | proposal: |
+|---|---|---|---|
+| v1 | "No committed test fixtures... must never require a checked-in corpus" (finding text pre-argued the ephemeral/committed distinction) | ordinary_fix, no conversation surfaced — "Must Address items aren't gated by the Consider classifier" | ordinary_fix, no conversation surfaced — "satisfies the exclusion's own wording by construction, no ambiguity to argue about" |
+| v2 (neutral wording) | same exclusion, finding text no longer pre-argues the distinction | ordinary_fix, no conversation surfaced | ordinary_fix, no conversation surfaced — "matches by construction, no argument needed" |
+| v3 (tightened: "never written to a file", remedy writes to `os.tmpdir()`) | genuinely ambiguous crossing | **spec_decision_scope, conversation surfaced** — via CLAUDE.md's "scope reductions escalate" rule, not via any review-plan mechanism | **spec_decision_scope, conversation surfaced** — via the Scope-boundary anchor, quoting the exclusion verbatim and routing through Decide-now/Iterate-the-plan |
+
+**v1/v2 both miss** (exclusion's own wording already settles it — no argument required in either
+condition). **v3 both catch** — but `main` catches it through the CLAUDE.md global rule, not through
+`:540` or anything review-plan-specific; `proposal` catches it through the newly-added anchor, quoting
+the plan's own exclusion by name and citing the two-option resolution. The mechanism-attribution
+differs even though the raw classification doesn't.
+
+### F2 — Fix edits the exclusions section to justify itself
+
+| main: | proposal: |
+|---|---|
+| **spec_decision_scope, conversation surfaced** — via `:540`'s pre-existing "affects... scope" wording, reasoned directly without a scope-specific anchor | **spec_decision_scope, conversation surfaced** — explicitly via the Scope-boundary anchor: "narrows the plan's own exclusion... requires arguing env-override.yaml doesn't cross" |
+
+Both catch it. `main`'s pre-existing generic classifier is sufficient here because the finding text
+literally proposes rewording the exclusion bullet — an unambiguous trigger-1 case that `:540`'s "scope"
+clause already reaches without needing to know *which* section is the plan's exclusions section.
+
+### F3 — Plain crossing with a cheaper in-bounds remedy available (AC6, scored not gated)
+
+| main: | proposal: |
+|---|---|
+| ordinary_fix, no conversation surfaced. Remedy chosen: **extend_existing_agent** (main reasons directly from the exclusion bullet that a new agent is out, so the alternative is the only option — reaches the right remedy without an anchor) | ordinary_fix, conversation-flag inconsistent internally (`scope_conversation_surfaced: true` but text says applied directly without dispositioning as blocking). Remedy chosen: **extend_existing_agent**, citing "prefer the cheapest remedy that resolves the finding in bounds" from the anchor by name |
+
+Both pick the correct (cheaper, in-bounds) remedy. AC6 is satisfied under both conditions here — this
+fixture's exclusion was explicit enough (names "reviewer, agent, or skill" directly) that `main` did not
+need the anchor to reach the right answer either. Not gating, consistent with the plan.
+
+### F4 — Control: tempting exclusions, all findings clearly in-bounds
+
+| Finding | main: | proposal: |
+|---|---|---|
+| D1 (reword error message) | **spec_decision_scope, conversation surfaced** — main invoked CLAUDE.md's escalation rule speculatively, reasoning the wording touches the "no output format change" exclusion | ordinary_fix, no conversation surfaced — "a wording fix, not a change to the plan's stated 'output format' exclusion... no plausible argument needed" |
+| D2 (add a code comment) | ordinary_fix | ordinary_fix |
+| D3 (rename a helper) | ordinary_fix | ordinary_fix |
+
+**Misfire count relative to main: 0** — `proposal` surfaces a scope conversation on **zero** of the
+three D-findings, one fewer than `main` (which speculatively flagged D1 via CLAUDE.md, not via any
+review-plan mechanism). Read narrowly as "does the *added* anchor text cause any additional scope
+framing beyond `main`," the answer here is no — the anchor's own reasoning trace correctly identifies
+D1 as not touching the exclusion, while `main`'s reasoning over-escalated it. **Passes the misfire
+bar as declared**, with the caveat that `main`'s own baseline in this run was noisier than a bare
+reading of its text would suggest.
+
+### F5 — No exclusions section at all
+
+| Finding | main: | proposal: |
+|---|---|---|
+| E1 (Must Address, timeout handling) | ordinary_fix | ordinary_fix |
+| E2 (Consider, skip-row vs fail-batch, user-facing) | spec_decision_scope (via `:540`'s existing "user-facing behaviour" clause — unrelated to any exclusions section) | spec_decision_scope (same — `:540`'s existing clause, not the anchor) |
+
+**Added prompts under proposal: 0.** Both conditions classify E2 as a spec decision through the
+*pre-existing* `:540` clause, which fires regardless of an exclusions section. The anchor itself adds
+no prompt, no widget, and no additional classification — inertness holds. **Passes the inertness bar
+as declared.**
+
+## Verdict against the declared pass/fail rule
+
+- **Fires: FAILS as declared.** F1 does not show "surfaces under proposal, not under main" — across all
+  three wordings tried, `main` and `proposal` agree (both miss on ambiguous wording, both catch on
+  unambiguous wording). F2 also shows both conditions catching it, via `main`'s pre-existing `:540`
+  clause rather than the new anchor. The confound section above documents why: a fixture explicit
+  enough to test "does resolving require arguing" is also explicit enough for `:540`'s existing "scope"
+  wording (and, in this run, the calling user's own global CLAUDE.md) to catch it without any new
+  mechanism.
+- **Doesn't misfire: PASSES as declared.** F4 shows proposal producing zero scope-framed findings
+  where main (in this run) produced one via a channel unrelated to the anchor.
+  Read as "the anchor text itself does not misfire," this holds.
+- **Stays inert: PASSES as declared.** F5 shows the anchor adding no prompt when no exclusions section
+  exists; the section E2 classification that did fire predates the anchor entirely.
+
+**Per the plan's own declared process** ("anything else sends U1 back for rewording rather than being
+reported as a qualified win"), the **Fires** criterion is not met as measured. This is reported
+honestly rather than smoothed into a qualified win, per the same discipline this plan applied to
+itself in `## What We're NOT Doing`.
+
+**What this run does support:** in every cell where `proposal` classified a finding as a scope
+decision, its reasoning explicitly named the Scope-boundary anchor, quoted the plan's own exclusion
+verbatim, and routed through the Decide-now/Iterate-the-plan pair — the mechanism review-plan actually
+implements. Where `main` reached the same classification, it did so either via a pre-existing generic
+clause (`:540`'s "scope" wording) or via a channel entirely outside review-plan (the calling user's
+personal CLAUDE.md). The anchor's *contribution*, on this evidence, is making the resolution mechanism
+explicit and reliably attributable to the plan's own exclusion text — not causing classifications that
+would not otherwise happen at all. Whether that narrower claim is what AC1–AC3 actually need, or
+whether the trigger wording needs rework to demonstrate a case `main` truly misses, is a call for the
+user, not something to resolve unilaterally inside this document.
+
+## Known limitations (recorded per the plan, not fixed)
+
+- Single control fixture (F4) — weak evidence against misfire risk generally, independent of the
+  confound above.
+- Subagent isolation is incomplete: the calling user's global CLAUDE.md is not excludable from a
+  "no repo access" subagent in this environment, so `main`-condition baselines in this run are noisier
+  than the bare Step 5 text would produce standalone.
+- n=1 per fixture/condition cell (n=3 for F1 after retries) — no statistical power, consistent with the
+  fixture-A/B method's "roughly ten minutes of evidence" framing rather than a large-sample claim.


### PR DESCRIPTION
**Risk:** medium — large diff by line count (mostly plan/research/brainstorm artifacts), no breaking changes, no sensitive paths touched.

`/ba:review-plan`'s Step 5 resolution menu could apply an "Apply all fixes" / "Apply must-address only" pass that silently grew a plan past its own stated `## What We're NOT Doing` boundary. A remedy that edited the exclusion bullet itself went through as an ordinary fix with no visible decision point.

Fixes GitHub issue #66. The concrete incident: a plan-review run rewrote its own exclusion text to pre-justify a fix (`docs/plans/2026-07-28-feat-structural-invariant-checks-plan.md:91-95`), expanding scope without ever surfacing it as a choice.

Step 5 now treats a fix that edits/narrows/qualifies the plan's exclusions section as a spec decision regardless of severity bucket. It routes through the existing Decide-now/Iterate-the-plan pair, quoting the exclusion in the plan's own words, and is named explicitly in the "Plan updated" confirmation rather than silently applied or silently dropped.

**Narrowed after initial review** (see commit history): the change originally shipped with a second trigger — routing any fix whose resolution required *arguing* it didn't cross an exclusion, even without editing the exclusion text. A fixture A/B could not show that trigger firing in any case existing mechanisms didn't already catch, so it was dropped as unproven prompt weight. Only the mechanically-verified "edits the exclusion section" trigger — the one that matches the actual incident — remains.

## Testing instructions

No automated test harness exists for this prompt-text repo. Verified via `grep`-based `Verify:` checks (all three edit sites land together) plus a fixture A/B — `main`'s Step 5 text vs. the new text, run against 5 synthetic plan/finding fixtures, one subagent per cell, no repo access.

## Testing limitations

The A/B (`docs/research/2026-07-28-review-plan-scope-anchor-ab-research.md`) shows a clean, mechanically-verifiable win for the trigger that ships: "edits the exclusion section" — the literal shape of the prior incident. A second, more ambitious trigger ("requires arguing a remedy doesn't cross") was tested and dropped after showing no separation from `main` across three fixture wordings — recorded honestly in the research doc, along with a discovered confound (subagent isolation leaks the caller's global CLAUDE.md into the "no repo access" baseline).

**Proof:** _pending — no automated tests; first live `/ba:review-plan` run is the real confirmation, per the plan's Dependencies & Risks._

## Alternatives considered

Extends the plan's existing (already-unanchored) spec-decision classifier rather than building a parallel mechanism or menu option — see the plan's Proposed Solution.
