### PR TITLE
fix(ba-plan): remove the write-early contradiction around the pre-write gate

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-workflow",
-  "version": "0.40.0",
+  "version": "0.40.1",
   "description": "Nine skills for research, brainstorm, plan, review-plan, execute, review, compound, handoff, and propose — with triage, convention compliance, and knowledge compounding",
   "author": {
     "name": "Bruno Azevedo"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ Claude Code plugin providing brainstorm and plan skills with triage, convention 
 - Bump `version` in `.claude-plugin/plugin.json` for every release
 - Planning skills (brainstorm, plan, review-plan) must never write code — only research and document
 - Execution skills (execute) implement approved plans — the plan is the authority on what to build
-- Convention-compliance check is mandatory before writing planning artifacts (brainstorms, plans) to disk
+- Convention-compliance check is mandatory before writing planning artifacts (brainstorms, plans) to disk. **Only `ba-plan` currently enforces the ordering** — its Steps 4/5/7 state the in-context-until-Step-7 sequence explicitly, so nothing instructs a write before the gate resolves. `ba-brainstorm` does **not**: Phase 3 writes the artifact, its template carries an "[Appended by convention-checker]" placeholder, and Phase 3.5 gates *after* the write. Read the brainstorm path as known debt (#65), never as the reference implementation to copy.
 - Research docs (`docs/research/`) are exempt — they are pre-convention ephemeral artifacts
 - Agents may declare `tools` in frontmatter to restrict available tools (e.g., locator agents use Grep, Glob, LS only — no Read)
 - `/ba-review` selection is a stateless per-diff judgment — every reviewer (built-in and discovered external) appears in the **selection ledger** each run, selected or set aside with a one-line reason, and is reachable via **Adjust**. Reviewers are never silently dropped; no selection state is persisted. (This never-hide convention is mirrored in `README.md`, `skills/ba-review/SKILL.md` Step 2, and `skills/ba-review-plan/SKILL.md` (Step 2, judged section-scoring ledger over the 7 built-ins) — keep them in sync.)

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ A **soft confidence gate** at consolidation suppresses (not drops) findings belo
 
 ## Convention Compliance
 
-Both brainstorm and plan skills run a **mandatory convention-compliance check** before writing artifacts to disk. This closes a gap shared by all three reference systems: no explicit step that compares output against project rules.
+Both brainstorm and plan skills run a **mandatory convention-compliance check** on their artifacts. This closes a gap shared by all three reference systems: no explicit step that compares output against project rules. In `/ba-plan` the check runs strictly before the file reaches disk; in `/ba-brainstorm` it currently runs after the write, as an in-place amendment (known debt).
 
 The `convention-checker` agent reads your CLAUDE.md and project conventions, compares them against the draft, and classifies each as:
 

--- a/skills/ba-plan/SKILL.md
+++ b/skills/ba-plan/SKILL.md
@@ -222,7 +222,8 @@ After structuring the plan, run the spec-flow analyzer to validate completeness:
 
 ## Step 4: Draft the Plan
 
-Write the plan using the chosen detail level template.
+Compose the plan in context using the chosen detail level template. It does not reach disk until
+Step 7.
 
 ### Structured Metadata (all levels) — YAML frontmatter for markdown, visible-text header for HTML
 
@@ -606,7 +607,7 @@ findings:
    defined mechanism yet; until it does, treat the interactive path as the default and this as the
    fallback for when a prompt cannot be presented.
 
-**5. Append compliance summary** to the plan's end (as before):
+**5. Add the compliance summary** to the end of the in-context draft:
    ```markdown
    ## Convention Compliance
    - [x] [Convention A] — aligned
@@ -635,7 +636,8 @@ If anything was dropped, add it back before writing.
 
 ## Step 7: Write & Present
 
-**REQUIRED: Write the plan file to disk before presenting options.**
+**The plan file reaches disk here, once Steps 5 and 6 have resolved. It must exist before the
+handoff menu is presented.**
 
 ```bash
 mkdir -p docs/plans/


### PR DESCRIPTION
Closes #65.

`ba-plan` told the model two contradictory things about when the plan file is written to disk. Step 5 is named **Pre-Write Decision Gate** and says "MANDATORY. Run before writing the plan to disk" — but a real run wrote the plan four minutes and eleven `convention-checker` edits before that gate ran. The step order was already correct; the prose pulled the other way.

## What was contradictory

#65 blamed Step 5's ordering claim against Step 7's "REQUIRED: Write the plan file to disk before presenting options". Both are real, but the two strongest write-early pulls were at sites #65 didn't mention:

- **Step 4** said "Write the plan using the chosen detail level template" — a bare imperative, no in-context qualifier. "Draft" appeared only in the heading.
- **Step 5 item 5** said "Append compliance summary to the plan's end (as before)". The gate step forbade the write and then instructed an append to the artifact. `(as before)` was dangling residue with no referent.

## The change

Four wording edits, no new mechanism:

| Site | Now |
|---|---|
| Step 4 | "Compose the plan in context… It does not reach disk until Step 7." |
| Step 5 item 5 | "Add the compliance summary to the end of the in-context draft" |
| Step 7 | "The plan file reaches disk here, once Steps 5 and 6 have resolved. It must exist before the handoff menu is presented." |

The file already owned the vocabulary — Step 3 says "park it (in your running context, never in the plan document)" — it just wasn't applied at Step 4 or item 5.

Step 7 names **Step 6** as well as Step 5 because Step 6 (Brainstorm Cross-Check) also mutates the draft before the write: "If anything was dropped, add it back before writing." Naming only Step 5 would license writing at Step 5's end and treating Step 6 as a post-write check — a narrower instance of the same bug. Found by review; the original reconciliation checked Steps 0.0/4/5/7 and missed it.

## Why no fixture A/B

The A/B convention attaches to behavioral claims. Removing a self-contradiction makes none — "append to the plan's end" inside a step that forbids writing the plan is incoherent whether or not a model trips on it.

The claim-bearing variant — a standalone "do not write before Step 5 resolves" prohibition, following `ba-execute`'s ordering-invariant pattern — is **deferred, not shipped untested**. Its A/B was undecidable in advance: the baseline is n=1, and #65 records both pre-merge harness runs sequencing correctly, so the `main` arm had no room to show a reduction. That is exactly the floor effect the preceding 36-session probe documented in `docs/solutions/prompt-authoring/2026-07-31-probe-instrument-validation-false-zeros.md`, whose prescription is to pilot the baseline arm before trusting a predicted one.

## Known gaps, stated deliberately

- **No fresh-session dry run.** The sequencing change is unverified in a real session — only the prose is now internally consistent. Declining the full A/B is defensible; declining every empirical check is a gap.
- **`ba-brainstorm` has the same defect and worse** — Phase 3 contains the write, its template ships an "[Appended by convention-checker]" placeholder, and Phase 3.5 then claims to run before the write, so write-then-append is that file's designed behavior. Left alone: brainstorm artifacts are lower-stakes because `ba-execute` doesn't auto-detect them. `CLAUDE.md`'s joint convention line and `README.md`'s restatement are amended to record the asymmetry rather than keep overclaiming: the rule stands, but only `ba-plan` enforces the ordering, and the brainstorm path is now named as known debt so it isn't copied as the reference implementation.
- **Producer-side only.** No marker or approval flag in `ba-execute`, which still accepts any file with `plan_schema: 2` plus loose structure. A frontmatter approval flag would cut against #31's read-only-plan / git-derived-state spine. This makes an ungated plan on disk less likely, not impossible.

Whether the gate should exist at all stays with #38 and #58.

## Verification

`node scripts/check-invariants.mjs` — 4/4 pass (sentinels, references, retired-invocations, version-bump 0.40.0 → 0.40.1).

Reviewed with `/ba-review` (complexity, architecture, simplification, test-coverage). Seven findings; the one confirmed defect — Step 7 omitting Step 6 — is fixed here. The rest are recorded above as known gaps rather than silently dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

