### PR TITLE
fix(ba-propose): report the capture disposition on every ship receipt

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-workflow",
-  "version": "0.45.0",
+  "version": "0.46.0",
   "description": "Nine skills for research, brainstorm, plan, review-plan, execute, review, compound, handoff, and propose — with triage, convention compliance, and knowledge compounding",
   "author": {
     "name": "Bruno Azevedo"

--- a/.claude/agent_docs/prompt-authoring.md
+++ b/.claude/agent_docs/prompt-authoring.md
@@ -140,3 +140,25 @@ not PASS — one copy left after a deletion must not read the same as two that a
 coverage at all — an orphaned one ships silently. Its needle also matches the bare and the
 `${CLAUDE_PLUGIN_ROOT}`-anchored spellings alike, so a promotion that moves the file without
 re-spelling its citers passes CI green. Both gaps are known and hand-maintained, not enforced.
+
+## Shipping: one bump, and how to read a local `version-bump` FAIL
+
+A ship gets **one** bump of `version` in `.claude-plugin/plugin.json`, however many commits it spans.
+The version is the plugin's autoupdate cache key, so a second bump added mid-branch doesn't produce a
+tidier history — it burns a version number that was never published, and consumers skip it.
+
+That collides with how the `version-bump` check reads history. It compares `HEAD~1..HEAD` — exactly one
+commit. On a branch, `HEAD~1` is the previous *branch* commit, so **every** prompt-surface commit except
+the one that happens to carry the bump reads `FAIL: version unchanged while skills/, agents/,
+references/ changed`. A branch that bumps in its third commit and touches `skills/` in its fifth will
+fail locally at the fifth, while being perfectly correct.
+
+In CI the same comparison means something different. On `pull_request`, GitHub checks out an ephemeral
+merge commit whose first parent is the base branch tip, so `HEAD~1..HEAD` spans the PR's **cumulative**
+diff — where the single bump sits alongside every prompt-surface change it covers, and the check passes.
+(This is why `.github/workflows/invariants.yml` pins `fetch-depth: 0` and says not to shallow it.)
+
+So a local FAIL at a branch HEAD is expected output, not a defect to fix, and **never** a reason to add
+a bump. Confirm before acting: compare the branch's cumulative diff against its base and check whether
+*that* range carries a bump. Only a whole PR that touches `skills/`, `agents/`, or `references/` with no
+bump anywhere in it is the failure this check exists to catch.

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Documents solved problems into `docs/solutions/` so the `learnings-researcher` a
 
 - **5 parallel subagents** — Context Analyzer, Solution Extractor, Related-Docs Finder, Prevention Strategist, Category Classifier
 - **Frictionless manual / model-proactive** — a deliberate run proceeds directly once a problem/solution pair is identifiable (no confirmation gate); best invoked right after solving a non-trivial, verified problem
-- **Ship-time capture offer** — after a successful create, `/ba-propose` may offer to run `/ba-compound` when the change looks like it carried a reusable learning; otherwise it stays quiet, emitting a one-line suppression trace naming why (see the `/ba-propose` entry)
+- **Ship-time capture offer** — after a successful create, `/ba-propose` may offer to run `/ba-compound` when the change looks like it carried a reusable learning; either way the ship's terminal receipt names the capture disposition on its own line (see the `/ba-propose` entry)
 - **Explicit invocation** — `/ba-compound` or `/ba-compound [context hint]` for immediate documentation
 - **Structured output** — YAML frontmatter with `category`, `tags`, `module`, and `symptom` for maximum discoverability by `learnings-researcher`
 
@@ -204,7 +204,7 @@ Commit, push, and open a PR/MR with a composed title and body.
 - Commit message and PR/MR body share the same composed markdown — no separate render path
 - `--body-file` discipline (temp file + quoted-sentinel heredoc); no `git add -A`/`.`; no `--no-verify`; `--force-with-lease` only
 - **Apply-by-default** — every `ACTION` applies without a confirmation prompt by default; pass `--review` (alias `--interactive`) or set `BA_PROPOSE_REVIEW=1` to restore the Apply / edit / regenerate-with-hint / exit menu and the Step 0b edit-only confirm
-- **Ship-time capture offer** — after a successful create (and only then), a best-effort read-only assessment may offer to run `/ba-compound` on the just-shipped learning; silent on routine, uncertain, already-captured, and non-interactive ships (each now emits a one-line suppression trace naming why), and never on edit/describe-only/unknown-host paths
+- **Ship-time capture offer** — after a successful create (and only then), a best-effort read-only assessment may offer to run `/ba-compound` on the just-shipped learning; the terminal receipt names the capture disposition as its third line on every route that reaches it — offered, or suppressed as routine, uncertain, already-captured, non-interactive, or URL-unresolved — while edit/describe-only/unknown-host paths print no receipt at all
 
 ### `/ba-handoff [focus]`
 

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ Commit, push, and open a PR/MR with a composed title and body.
 - Commit message and PR/MR body share the same composed markdown — no separate render path
 - `--body-file` discipline (temp file + quoted-sentinel heredoc); no `git add -A`/`.`; no `--no-verify`; `--force-with-lease` only
 - **Apply-by-default** — every `ACTION` applies without a confirmation prompt by default; pass `--review` (alias `--interactive`) or set `BA_PROPOSE_REVIEW=1` to restore the Apply / edit / regenerate-with-hint / exit menu and the Step 0b edit-only confirm
-- **Ship-time capture offer** — after a successful create (and only then), a best-effort read-only assessment may offer to run `/ba-compound` on the just-shipped learning; the terminal receipt names the capture disposition as its third line on every route that reaches it — offered, or suppressed as routine, uncertain, already-captured, non-interactive, or URL-unresolved — while edit/describe-only/unknown-host paths print no receipt at all
+- **Ship-time capture offer** — after a successful create (and only then), a best-effort read-only assessment may offer to run `/ba-compound` on the just-shipped learning; the terminal receipt names the capture disposition on its own line (line 3, or line 2 when the ship URL is unresolved) on every route that reaches it — offered, or suppressed as routine, uncertain, already-captured, non-interactive, or URL-unresolved, or reported `unavailable` when the assessment itself failed — while edit/describe-only/unknown-host paths print no receipt at all
 
 ### `/ba-handoff [focus]`
 

--- a/docs/brainstorms/2026-08-11-ba-propose-5f-terminal-receipt-brainstorm.md
+++ b/docs/brainstorms/2026-08-11-ba-propose-5f-terminal-receipt-brainstorm.md
@@ -1,0 +1,189 @@
+---
+date: 2026-08-11
+topic: ba-propose-5f-terminal-receipt
+status: approved
+triage_level: full
+tags: [ba-propose, ba-compound, prompt-authoring, observability, cluster:compound, cluster:model-fit]
+---
+
+# `/ba-propose` Step 5f — make the capture disposition a field of the terminal receipt
+
+Resolves #85. Standalone from #81.
+
+## What We're Building
+
+`/ba-propose`'s `commit_push_create` chain currently ends in two independent emissions: Step 5e
+prints a self-contained two-line success block (`✓ <title>` / `<url>`, `skills/ba-propose/SKILL.md:720-733`),
+and Step 5f (`:735-887`) then prints a capture offer or a one-line suppression trace. In practice 5f
+routinely does not run, and because 5e's block is already well-formed without it, a skip is
+byte-identical to a clean finish.
+
+The fix moves the fire/suppress predicate **up** into 5d/5e, where `CREATED_PR_URL` is already in
+hand, and merges its outcome into a single three-line terminal receipt:
+
+```
+✓ <title>
+  <url>
+  capture: offer follows | suppressed — <reason-token> | unavailable
+```
+
+5f shrinks from ~150 lines of judgment to a short dispatch: when the resolved decision is *offer*,
+fire the existing `AskUserQuestion` and keep the existing accept-path outcome line. The four reason
+tokens (`ship-url-unresolved`, `non-interactive`, `already-captured`, `judged-not-reusable`) are
+preserved verbatim as the suppression vocabulary.
+
+This is for anyone shipping through `/ba-propose` who cannot tell, from the output alone, whether a
+learning was judged not worth capturing or the judgment never happened. The primary environment is a
+large shared work repository — many contributors, a shared `docs/solutions/` corpus — not the
+plugin's own repo. That cuts two ways worth stating: a lost capture is invisible to everyone, not
+just to the author, and a spurious one lands in a tree other people read. Both push the same
+direction as the design below (observability first, lean-silent precision retained), so the
+environment sharpens the motivation without changing the approach.
+
+## Why This Approach
+
+**The defect is that the trace has no reader.** #85's own framing is precise: 5f's four trace lines
+are printed *by the prose being skipped*, so the mechanism built to distinguish a skip from a correct
+silence works only in the case where it isn't needed. The repo has exactly one hard mechanism for
+making a step binding — the `[AUTO-SCORE: …]` verdict sentinel (`skills/ba-review-plan/SKILL.md:617-660`,
+read by `skills/ba-plan/SKILL.md:667-692`) — and it works because a *second process waits on the
+line*. 5f has no waiter, so the same string cannot be load-bearing there by construction.
+
+Hoisting supplies the missing structural pressure without inventing a waiter: the capture line
+becomes a **field of the one block the entire run exists to emit**. A dropped field makes 5e's own
+success output visibly malformed, where today a dropped step makes nothing look wrong. It also
+follows the repo's established hoist precedent — `ACTION` resolved once at Step 0b with `:104`
+forbidding downstream re-derivation, `PERSIST=false` set for the remainder of a run
+(`skills/ba-review/SKILL.md:213`), and `resolve-stack-base`'s "call once, early" invariant.
+
+**Rejected — one terminal composite block emitted from 5f.** Loudest possible signal, but it makes
+the `✓` success line an output of 5f, so a skip could suppress the visible success output entirely.
+That is the exact inversion #52 engineered against when it made capture failure-isolated. Trading a
+silent miss for an invisible successful ship is a worse failure.
+
+**Rejected as the build, retained as an experiment — the one-sentence variant.** State the receipt
+contract once in the Step 5 dispatch table (`:566-577`, read before any work happens) and change
+nothing structural. This is a live hypothesis, not a straw man:
+`docs/research/2026-07-26-opus5-context-engineering-fit-research.md` carries the Every datapoint that
+scaffolding "did not prevent early stopping and instruction-missing, it contributed to them," which
+makes 150 lines of terminal prose a candidate *cause* of the skip. It is retained as the cheap third
+arm the fixture-A/B convention requires (`.claude/agent_docs/prompt-authoring.md:82-84`), and it is
+allowed to win.
+
+**Rejected — a hook.** This repo runs no Claude Code hooks today (CI-only automation), and per #52's
+evidence hooks cannot read conversation content, so the assessment would lose its two conversational
+signals and degrade to trailers-plus-diff.
+
+## Key Decisions
+
+- **Success condition is receipt-always, not offer-accuracy.** The assessment's false-negative rate
+  stays the accepted residual the spec already names at `:884-887`. Rationale: one behavioral claim
+  to verify instead of two, and the observability gap is the defect actually reported.
+- **The three-line receipt holds on every path, including the offer path.** This reverses today's
+  rule that "the `AskUserQuestion` **is** this path's trace" (`:780`, `:841-855`). Rationale: a
+  conditional invariant cannot be greped, and would cover only the paths that already trace.
+- **The receipt is a machine-boundary contract, specified to the character.** Participants are the
+  skill body as emitter and the acceptance criterion / A-B scorer as reader. Line count and the
+  third-line token vocabulary are fixed literals. Rationale: the receipt's shape *is* the runtime
+  observable this change exists to create, and `.claude/agent_docs/prompt-authoring.md:61-63` rejects
+  verification that only proves text exists. **CI cannot pin it today** — the two-participant rule
+  lives in `load-site-mirror` (`prompt-authoring.md:130-136`) and needs two byte-identical blocks,
+  which a single emitter does not provide. Recorded as a knowingly-unpinned assertion, the same
+  status the protected-artifacts guard already carries.
+- **Failure isolation is preserved unchanged.** An exception in the hoisted resolver prints
+  `capture: unavailable` and the ship's exit status is untouched. Nothing on the capture path can
+  fail a ship that already succeeded.
+- **The `/ba-compound` invocation stays inside 5f.** Rationale: it keeps `CLAUDE.md`'s in-run
+  continuation criterion true, so `ba-compound` continues to justify omitting
+  `disable-model-invocation`, and `:908`'s hand-off pointer stays accurate.
+- **Standalone from #81.** #81's relocation of 5f inherits the receipt invariant as a stated
+  acceptance criterion. Rationale: the hoist leaves a short terminal block, which is what makes that
+  later extraction cheap rather than a rewrite.
+- **The `**Code-shape decision:**` block at `:744-752` is rewritten, not trimmed.** Its rationale
+  earns the sketch on the grounds that "the exact predicate + ordering + per-path trace is fixed by
+  this sketch" — untrue once the predicate lives in 5d/5e. Leaving it verbatim ships stale
+  justification (`prompt-authoring.md:53-55`).
+
+## Scope Boundaries
+
+Not doing:
+
+- Changing the assessment's signals or their weights (`:828-839`). Precision is out of scope by the
+  first key decision.
+- #58's removal of same-turn self-verification. Same cluster, separate ship.
+- Any Claude Code hook.
+- Reopening which command hosts the capture offer. #52 settled this (`/ba-propose` only — not
+  `/ba-review`, not both) and is closed; the frontmatter-`description` trigger surface shipped in the
+  same slice and was probed by `docs/research/2026-07-30-ba-skill-trigger-scoping-probe-research.md`.
+  No open issue owns further triggering work, so this is a settled decision this brainstorm inherits,
+  not deferred scope. Corpus quality is #53; corpus maintenance is #54 (deferred).
+- Relocating 5f's prose into a reference file (#81).
+- Adding a CI check for the receipt — no second participant exists to compare against.
+- The edit paths. `commit_push_edit`, `edit_only`, and `describe_only` stay traceless by
+  construction, as does `HOST=unknown` (exits in 5d).
+
+## Acceptance Criteria
+
+1. Every `commit_push_create` run that reaches 5e emits exactly three lines, the third matching
+   `capture: (offer follows|suppressed — (ship-url-unresolved|non-interactive|already-captured|judged-not-reusable)|unavailable)`.
+2. The offer path emits `capture: offer follows` **before** the `AskUserQuestion`, and the existing
+   accept-path outcome lines (`:789-792`) are unchanged.
+3. An exception anywhere in the hoisted resolver yields `capture: unavailable` and a zero exit; the
+   `✓` line and URL still print.
+4. `README.md:169` and `README.md:208` no longer describe suppression as the offer "staying quiet"
+   or being "silent".
+5. All five in-file mirror sites are updated together: `:30` (predicate ownership), `:572` (action
+   table), `:720-733` (5e output contract), `:737-742` (completeness framing), `:744-752`
+   (code-shape rationale). `:908` is explicitly confirmed unchanged.
+6. `.claude-plugin/plugin.json` carries exactly one bump (`0.45.0` → `0.46.0`) for this ship,
+   covering the co-shipped `skills/ba-review/SKILL.md` external-reviewer-example sanitization.
+7. `node scripts/check-invariants.mjs` reports PASS on all six checks.
+8. Fixture A/B over three arms (`main` / hoisted receipt / one-sentence) shows the receipt line
+   present in the hoisted arm on fixtures where `main` drops it. Per
+   `.claude/agent_docs/prompt-authoring.md:73-93`, fixtures plant the failure being prevented, and
+   per `docs/solutions/prompt-authoring/2026-07-28-fixture-ab-subagent-claude-md-inheritance.md` each
+   verdict is attributed to a specific source sentence or the cell is inconclusive.
+9. Post-merge, in a fresh session: the first real `commit_push_create` ship emits the three-line
+   receipt. This is the live check and, per
+   `docs/solutions/prompt-authoring/2026-08-08-hoisted-text-invisible-to-dispatched-subagents.md`, it
+   cannot be run from the session that writes the change.
+
+## Open Questions
+
+None.
+
+### Resolved Questions
+
+- *What counts as fixed?* → Receipt-always; assessment precision stays the accepted residual.
+- *Relationship to #81?* → Fix #85 standalone first; #81 inherits the invariant as an AC.
+- *Does the offer path carry a capture line?* → Yes. The three-line block is unconditional.
+- *Is the receipt a machine-boundary contract or steering?* → Machine-boundary, specified exactly,
+  with its CI-unpinnability recorded.
+
+## Convention Compliance
+
+Convention-checker run before this artifact reached disk. 14 conventions checked: 5 aligned,
+1 justified override, 5 violations (all resolved), 3 not applicable.
+
+- **README sync** (violation, resolved) — `README.md:169` and `:208` assert 5f "stays quiet" /
+  is "silent"; contradicted by receipt-always. Now an in-scope deliverable and AC4.
+- **Mirror-site enumeration** (violation, resolved) — four disturbed sites were missing from the
+  draft (`:30`, `:572`, `:737-742`, `:908`). Now enumerated in AC5.
+- **Trust gradient** (violation, resolved) — the draft specified a literal format while arguing no
+  second process reads it. Resolved by classifying the receipt as a machine-boundary contract with
+  emitter and AC-scorer as its two participants, and recording that CI cannot pin it.
+- **Misattributed CI rule** (violation, resolved) — the ≥2-participant rule belongs to
+  `load-site-mirror`, not `sentinels`. Corrected in Key Decisions.
+- **Version bump** (violation, resolved) — one bump to `0.46.0`, AC6.
+- **Justified override** — retaining rejected approach C as an A/B arm is what
+  `prompt-authoring.md:82-84` asks for; it stays in this brainstorm as an experimental condition and
+  is not carried into shipped prompt prose.
+- **Not applicable** — the U-ID and stack-base axis grid is untouched (5e/5f read no `<base>` and no
+  U-ID anchor, and the receipt adds no git-derived state); the `**Code-shape decision:**` *label*
+  convention is scoped to plan documents, so rewriting `:744`'s borrowed usage disturbs no mirror
+  site.
+- **Aligned** — public-safe artifact (in-repo paths and issue numbers only); planning skill writes no
+  code; fixture A/B is the deciding instrument; prompt weight decreases.
+
+## Next Steps
+→ `/ba-plan` to create implementation plan

--- a/docs/plans/2026-08-11-fix-ba-propose-5f-terminal-receipt-plan.md
+++ b/docs/plans/2026-08-11-fix-ba-propose-5f-terminal-receipt-plan.md
@@ -1,0 +1,377 @@
+---
+title: /ba-propose terminal capture receipt — hoist the 5f predicate into 5e
+type: fix
+plan_schema: 2
+status: active  # human-authored only — /ba-execute ignores this for control flow; progress is git-derived
+date: 2026-08-11
+origin: docs/brainstorms/2026-08-11-ba-propose-5f-terminal-receipt-brainstorm.md
+detail_level: standard
+tags: [ba-propose, ba-compound, prompt-authoring, observability]
+---
+
+# /ba-propose terminal capture receipt Implementation Plan
+
+## Overview
+
+`/ba-propose` Step 5f — the ship-time `/ba-compound` capture offer — is specified as a required
+terminal step but routinely does not run, and its own four trace lines cannot witness the skip
+because they are printed by the prose being skipped. The fix moves the fire/suppress predicate into
+Step 5e and merges its outcome into a single three-line terminal receipt, so the capture disposition
+rides the line the run exists to emit instead of trailing it as an optional step.
+
+**The experiment runs before the rewrite.** U1 scores the proposed mechanism against a one-sentence
+alternative; U2's rewrite is gated on that verdict. Building U2 first would authorize discarding it
+after it was already built.
+
+Resolves #85. Standalone from #81.
+
+## Current State
+
+- `skills/ba-propose/SKILL.md:720-733` — **5e** prints a self-contained two-line block
+  (`✓ <title>` / `  <url>`) plus an unparseable-URL guard that hands 5f a trace obligation.
+- `:735-887` — **5f**, ~150 lines: a two-part gate, four ordered silence preconditions each emitting
+  `5f: capture offer suppressed — <token>`, a best-effort assessment, the offer, and a `try` around
+  assessment + prompt + invoke.
+- `:884-887` — the self-referential closing claim: each silent path "leaves a one-line reasoned
+  trace, so a **skip** … is distinguishable from a **correct silence**."
+- `:30` — asserts 5f "gates on its own predicate (5e printed `✓ <url>` and
+  `ACTION == commit_push_create`)" and "Step 5 is not complete until 5f has *run*".
+- `:572` — the Step 5 action table renders `5e (output) → 5f (capture offer)` as two output stages.
+- `:875` — claims "the `try` boundary is unchanged … it still wraps only the assessment, prompt, and
+  invoke".
+- `:876-883` — the print-infallibility model, justified by 5e having "already wrote to it
+  microseconds earlier".
+- `README.md:169` — "otherwise it **stays quiet**, emitting a one-line suppression trace naming why".
+- `README.md:208` — "**silent** on routine, uncertain, already-captured, and non-interactive ships".
+- `.claude-plugin/plugin.json` — `0.45.0`. Working tree carries an uncommitted
+  `skills/ba-review/SKILL.md` sanitization (external-reviewer example renamed off a private-repo
+  agent name) awaiting this ship's bump.
+- No Claude Code hooks exist in this repo; automation is CI-only via `scripts/check-invariants.mjs`
+  (six checks).
+
+## Acceptance Criteria
+
+- AC1: Every route that prints a 5e success line emits a contiguous three-line block whose third
+  line is `capture: <value>`, where `<value>` is one of exactly six literals.
+  - When the URL is unresolved, the URL line is omitted and the block is two lines — the `✓` line and
+    the `capture: suppressed — ship-url-unresolved` line. This is the one legitimate sub-three-line
+    receipt, and it is distinguished from a partial print by the `capture:` line being **present**: a
+    genuine partial print emits the `✓` line alone.
+- AC2: The six-value enum is closed and exhaustive: `judged-reusable`,
+  `suppressed — ship-url-unresolved`, `suppressed — non-interactive`,
+  `suppressed — already-captured`, `suppressed — judged-not-reusable`, `unavailable`.
+- AC3: The offer path's line 3 states a decision already made (`judged-reusable`), never a
+  prediction — so no later failure of the `AskUserQuestion` or the `/ba-compound` invoke can
+  contradict a receipt already flushed.
+- AC4: A resolver exception prints `capture: unavailable`, still prints the `✓` line, and leaves the
+  ship's exit status zero. The ground for the exit-status guarantee is that **exit status is already
+  determined before 5e runs at all** — 5c's push and 5d's create decide it, and 5e/5f contain no
+  statement that can alter it. The retired circular ground (5e's earlier write proves stdout healthy)
+  is not restated.
+- AC5: The retired token `5f: capture offer suppressed` appears nowhere in `skills/`.
+- AC6: All five in-file mirror sites are changed in one unit, so no intermediate commit states two
+  contradictory predicate owners: `:30`, `:572`, `:720-733`, `:737-742`, `:744-752`.
+- AC7: `:729-733`'s standard is amended to scope its observability guarantee to routes that reach
+  5e, so the file stops asserting a guarantee the `HOST=unknown` route does not satisfy.
+- AC8: `README.md:169` and `:208` no longer describe suppression as staying quiet or being silent.
+  `README.md:145` ("stays silent", about `/ba-review-plan`) is untouched.
+- AC9: `.claude-plugin/plugin.json` reads `0.46.0` — one bump for this ship, covering the co-shipped
+  `skills/ba-review/SKILL.md` sanitization.
+- AC10: `node scripts/check-invariants.mjs` reports PASS on all six checks.
+- AC11: The three-arm fixture A/B produces a recorded score table with a **pre-committed decision
+  rule**: the one-sentence arm wins if it produces the `capture:` line on all four fixtures while
+  touching ≤ 2 lines of prose; the hoisted arm wins if the one-sentence arm misses the line on any
+  fixture. Any other outcome is inconclusive and returns to a decision round rather than defaulting
+  to either arm.
+- AC12: The A/B's score table is captured somewhere durable — the ship's PR/MR body — so AC11 stays
+  checkable by a later reader rather than living only in an agent's ephemeral output.
+- AC13: The rewrite unit does not begin until AC11's verdict is recorded.
+
+## What We're NOT Doing
+
+Inherited from the origin brainstorm:
+
+- Changing the assessment's signals or weights (`:828-839`). Precision stays the accepted residual.
+- #58's removal of same-turn self-verification.
+- Any Claude Code hook.
+- Relocating 5f's prose into a reference file (#81).
+- A CI check for the receipt — `load-site-mirror` needs two byte-identical blocks and there is one
+  emitter.
+- The edit paths. `commit_push_edit`, `edit_only`, `describe_only` stay traceless.
+- Reopening which command hosts the offer (#52 settled it).
+
+Decided during planning:
+
+- **No Failure Modes row.** Spec-flow proposed adding one; the origin never asked for it, its
+  recovery text already exists verbatim at `:874`, and `## Failure Modes:894` already carries a
+  `HOST=unknown` row. Dropped as scope growth rather than folded in silently.
+- **No new `CLAUDE.md` bullet for the enum.** Review pushed back that the "single emitter" reasoning
+  answers the wrong question — the risk is single-*description*-site, and AC6 proves there are seven.
+  The bullet still isn't the remedy; the fan-out is instead named as a recorded cost in
+  Dependencies & Risks, and U2 carries an in-file pointer naming 5e as canonical.
+- **`HOST=unknown` stays un-receipted.** The route never reaches 5e and #52 deliberately excluded
+  unknown-host ships. AC7 amends the prose rather than adding a fifth token.
+- **A resolver exception forecloses capture for that ship**, with no retry. Accepted as the cost of
+  graceful degradation; manual `/ba-compound` is the escape hatch.
+
+## Proposed Solution
+
+Resolve the predicate in **5e only** — not "5d/5e". `ship-url-unresolved` is unknowable in 5d, whose
+contract ends at "create exited 0 and `CREATED_PR_URL` was captured"; the empty-or-malformed judgment
+belongs to 5e's existing guard. One resolver, one emit site, one contiguous block.
+
+What the change actually buys, stated precisely so no acceptance criterion overclaims: **co-location,
+not a guarantee.** A three-line block printed by 5e prose is still absent if that prose is skipped.
+The gain is that line 3 rides the URL line the model reliably prints, so the predicted failure shifts
+from "an entire terminal step vanished with no trace" to "printed 2 of 3 lines" — externally
+detectable, and the thing AC1 pins.
+
+That admission is also why U1 runs first. If a single sentence achieves the same co-location, the
+resolver, the second isolation boundary and the five-site rewrite are unearned.
+
+## Technical Considerations
+
+**Ordering.** Every assessment input is settled well before 5e: `deviation_trailers` (2f), `risk`
+(2h), `proof` (2e), `sensitive_paths_touched` (2g), `solutions` (2c), commit type (Step 3), and the
+conversation arc (ambient, only grows). No input is read before it materializes.
+
+**Accepted on the record:** the resolver now sits between PR creation and the user seeing the URL, so
+a slow assessment delays the printed URL. The `try` guards a *thrown* exception, not a hung
+assessment — there is no timeout, and a hang stalls the whole receipt rather than just line 3.
+Accepted rather than mitigated: a timeout is machinery this defect does not justify, and the
+assessment reads only already-materialized state.
+
+**`already-captured` is keyed on a user choice, not a fact.** `solutions` holds the entries the user
+*accepted* at 2c; choosing "Skip all" yields an empty tuple even when `docs/solutions/` files ride
+the PR. Pre-existing, unchanged here, but now printed on every affected ship. Noted, not fixed.
+
+**`proof=visual` and 5d's re-extract** are inert on the create path — 2d sets `preserved_blocks = ()`
+for `commit_push_create` with no open PR (`:288`) — so the resolver sitting on the same side of 5d as
+the re-extract introduces no staleness.
+
+## System-Wide Impact
+
+- **Interaction graph**: 5e gains a resolver; 5f becomes its consumer. `/ba-compound` stays invoked
+  from 5f, which keeps `CLAUDE.md`'s in-run-continuation criterion true and `:908`'s hand-off pointer
+  accurate — so no `disable-model-invocation` flag moves.
+- **Error propagation**: two isolation boundaries now exist where one did. The resolver's exception
+  degrades to `capture: unavailable`; 5f's existing `try` still degrades the prompt/invoke path to
+  "PR is live; capture failed". URL validity is checked **outside** the resolver's boundary so
+  `ship-url-unresolved` always wins over `unavailable` — and because that check returns before the
+  `try`, the two cannot both fire, making the precedence structural rather than a tie-break rule.
+- **State lifecycle risks**: none. The resolver is read-only and mutates nothing; no git-derived
+  state is added, so neither the U-ID nor the stack-base axis is touched.
+
+## Implementation Approach
+
+### Changes Required
+
+### U1 — Run the three-arm fixture A/B, and record the verdict
+
+Per `.claude/agent_docs/prompt-authoring.md:73-93`: four fixtures with planted ground truth covering
+the create-offer, create-suppressed, unparseable-URL, and `HOST=unknown` routes; three conditions
+(`main` / the hoisted receipt / the one-sentence arm that states the receipt contract once in the
+Step 5 dispatch table and changes nothing structural); one subagent per cell at the session model,
+given the spec excerpt only and no repo access; scored on what it fixes **and** what it costs.
+
+Decision rule is pre-committed per AC11 — the one-sentence arm wins on all four fixtures at ≤ 2 lines
+of prose; the hoisted arm wins if the one-sentence arm misses any fixture; anything else is
+inconclusive and returns to a decision round. Score table lands in the ship's PR/MR body (AC12).
+
+Per `docs/solutions/prompt-authoring/2026-07-28-fixture-ab-subagent-claude-md-inheritance.md`,
+attribute every verdict to a specific source sentence or mark the cell inconclusive — the caller's
+global `CLAUDE.md` loads into subagents and has already contaminated one baseline in this repo.
+
+**If the one-sentence arm wins, U2 is not built.** Ship the sentence, keep U3 and U4, and record the
+outcome on #85.
+
+**This unit is commit-tag-only.** No code-matchable, read-only `Verify:` exists: the A/B is a runtime
+procedure over subagents with no repo access, its output is a score table, and no fixtures are
+committed to this repo. It resolves to `done` only via its `U1` commit subject.
+
+Test scenarios:
+- The hoisted arm emits the `capture:` line on fixtures where `main` omits it entirely (Covers AC11)
+- The one-sentence arm is scored on the same four fixtures against the pre-committed rule, not assumed to lose (Covers AC11)
+- Each cell's verdict cites the sentence that produced it, or is marked inconclusive (Covers AC11)
+- The score table is readable in the PR/MR body after the fact (Covers AC12)
+
+**File**: `skills/ba-propose/SKILL.md`
+
+### U2 — Move the predicate to 5e and make the receipt its third line
+
+Gated on U1's verdict (AC13). One unit owns every site in this file, because AC6 forbids an
+intermediate commit in which the file names two predicate owners. Concretely:
+
+- **5e (`:720-733`)** — replace the two-line block with the three-line receipt; `✓ <title>` first,
+  URL second, `capture:` third. State the enum as closed. Amend the guard paragraph per AC7 so its
+  observability standard applies to routes reaching 5e. Carry a one-line pointer naming 5e as the
+  canonical enum site and listing its restatements (`:30`, `:572`, `:737-742`, `:744-752`,
+  `README.md:169`/`:208`) so a maintainer landing elsewhere can find the source.
+- **5f (`:735-887`)** — shrink to a dispatch: on `judged-reusable`, fire the existing
+  `AskUserQuestion` and keep the existing accept-path outcome lines (`:789-792`) unchanged. **Every
+  other resolved value, including the unresolved-URL route's, is a no-op** — one branch, not five.
+  Delete the four `5f: capture offer suppressed` emit sites (the resolver now owns them) and the
+  self-referential closing paragraph at `:884-887`. Reverse the offer-path rule at `:780`/`:841-855`:
+  the widget is no longer its own trace.
+- **Rewrite the `**Code-shape decision:**` block (`:744-752`)** — its justification ("the exact
+  predicate + ordering + per-path trace is fixed by this sketch") stops describing 5f once the
+  predicate leaves. The label string stays byte-identical; only the rationale and sketch change.
+- **Repair two now-invalid arguments** — `:875`'s "the `try` boundary is unchanged" is false once the
+  assessment moves out. `:876-883`'s print-infallibility rests on 5e having already written to
+  stdout, which is circular once the receipt *is* the first write; replace it with AC4's ground —
+  exit status is fixed by 5c/5d before 5e runs, so no print in 5e or 5f can alter it.
+- **`:30`** — remove "gates on its own predicate"; the invariant becomes "the receipt printed", not
+  "5f has run". **`:572`** — the action table stops rendering 5e and 5f as two output stages.
+- **`:908`** — confirmed unchanged (the `/ba-compound` invocation stays in 5f).
+- Record `interactive_session()` as deliberately model-judged: per the trust gradient this is
+  steering, not a machine boundary, and one line saying so prevents a future reviewer flagging it as
+  a dead branch under `prompt-authoring.md:59-60`.
+
+**Code-shape decision:** the resolver's ordering is the load-bearing decision and re-deriving it from
+prose plausibly produces a wrong structure — URL validation inside the exception boundary (making
+`ship-url-unresolved` unreachable and `unavailable` win), the interactivity check after the
+assessment (paying for a judgment that cannot be offered), or `judged-reusable` restored as a
+forward-looking promise. Anchors to the origin brainstorm's receipt contract; the enum literals are
+that contract and are not paraphrased.
+
+```
+# 5e. Output — one contiguous receipt. Line 3's value set is CLOSED (six literals).
+# CANONICAL SITE for the enum. Restated at :30, :572, :737-742, :744-752, README:169/:208 —
+# update together; no CI check pins this.
+print(f"✓ {title}")
+if is_url(CREATED_PR_URL): print(f"  {CREATED_PR_URL}")
+
+# Validity is judged HERE — empty OR malformed — outside the resolver's exception boundary, and it
+# RETURNS before the try, so ship-url-unresolved and unavailable can never both fire.
+if not is_url(CREATED_PR_URL):
+    print("  capture: suppressed — ship-url-unresolved"); goto 5f_dispatch(decision=None)
+
+try:                                     # resolver boundary #1 → degrades to `unavailable`
+    if not interactive_session():         # model-judged; deliberately unspecified (steering)
+        decision = "suppressed — non-interactive"
+    elif solutions:                       # 2c: entries the user ACCEPTED, not files on disk
+        decision = "suppressed — already-captured"
+    elif not assess_reusable_learning(deviation_trailers, conversation_arc,
+                                      commit_type, risk, proof):
+        decision = "suppressed — judged-not-reusable"   # negative OR uncertain → lean-silent
+    else:
+        decision = "judged-reusable"      # a DECISION, not a promise: no later failure falsifies it
+except Exception:
+    decision = "unavailable"              # exit status was fixed by 5c/5d; nothing here alters it
+print(f"  capture: {decision}")
+# 5f dispatch: judged-reusable → fire the offer. Every other value → no-op.
+```
+
+Test scenarios:
+- A create ship with a reusable learning prints `capture: judged-reusable`, then the offer appears (Covers AC1, AC2, AC3)
+- The `AskUserQuestion` throws after line 3 flushed; the receipt is still true and the ship exits zero (Covers AC3, AC4)
+- A create ship whose URL is non-empty but malformed takes the `ship-url-unresolved` branch, not the resolver (Covers AC1, AC2)
+- A resolver exception prints `capture: unavailable` with the `✓` line intact and exit status zero (Covers AC4)
+- The five silent routes — `HOST=unknown`, post-push create failure, and the three edit paths — emit no receipt fragment (Covers AC7)
+- Reading the file end-to-end, no passage claims 5f owns the predicate or grounds exit status on 5e's earlier write (Covers AC5, AC6, AC7)
+
+Verify: `grep -q 'capture: {decision}' skills/ba-propose/SKILL.md && ! grep -q '5f: capture offer suppressed' skills/ba-propose/SKILL.md && ! grep -q 'gates on its own predicate' skills/ba-propose/SKILL.md && awk '/capture: \{decision\}/{r=NR} /Document this learning/{p=NR} END{exit !(r && p && r < p)}' skills/ba-propose/SKILL.md`
+
+**File**: `README.md`
+
+### U3 — Correct the two user-facing claims that suppression is silent
+
+`:169` (under `/ba-compound`) and `:208` (under `/ba-propose`) both describe the offer as staying
+quiet or silent with a trace. Under receipt-always the disposition prints on every create ship, so
+both become one-line statements that the terminal receipt names the capture disposition.
+`README.md:145` ("stays silent") belongs to `/ba-review-plan` and must not be touched.
+
+Test scenarios:
+- Reading the `/ba-propose` feature list, a user learns the receipt always reports the capture disposition (Covers AC8)
+- `/ba-review-plan`'s description is byte-identical to before (Covers AC8)
+
+Verify: `grep -q 'receipt names the capture disposition' README.md && ! grep -q 'stays quiet' README.md && ! grep -q 'silent on routine' README.md && grep -q 'stays silent' README.md`
+
+**File**: `.claude-plugin/plugin.json`
+
+### U4 — One version bump for this ship
+
+`0.45.0` → `0.46.0`. Covers this change and the `skills/ba-review/SKILL.md`
+external-reviewer-example sanitization already in the working tree. One bump per ship — do not add a
+second if the branch already carries one.
+
+Test scenarios:
+- A fresh `--plugin-dir` load picks up the new bodies rather than the cached 0.45.0 (Covers AC9)
+
+Verify: `grep -q '"version": "0.46.0"' .claude-plugin/plugin.json && ! grep -rqi 'dragon' skills/ README.md CLAUDE.md && node scripts/check-invariants.mjs`
+
+## Dependencies & Risks
+
+- **Prompt-only change; cannot be dry-run in the session that writes it.** A session executes the
+  body it loaded at start. Verification is U1's fixture A/B plus a fresh-session
+  `claude --plugin-dir <repo>` run. Per the standing preference, the merge is not gated on the
+  real-harness run.
+- **The live check requires a real ship.** `describe_only` never reaches 5e, so the only route that
+  exercises the receipt end-to-end is an actual `commit_push_create`. In practice this change's own
+  ship is its first live test.
+- **U2 may not be built at all.** If U1's one-sentence arm wins, U2 is dropped and U3/U4 still ship.
+  Plan for that outcome rather than treating it as failure.
+- **U2 is a large single unit by design.** AC6 forces it; splitting to shrink the diff reintroduces
+  the contradictory-intermediate-commit problem the "together" wording exists to prevent.
+- **The receipt is a seven-site hand-maintained fan-out.** Five sites in `skills/ba-propose/SKILL.md`
+  plus two in `README.md` restate the enum, with no CI check (declined above) pinning them. AC6
+  solves this landing; it does not reduce the steady-state cost. **Any future enum change — a seventh
+  literal, a renamed token — pays the seven-site tax again.** U2's canonical-site pointer is the only
+  mitigation; recorded here so the next maintainer inherits a stated trade rather than a discovery.
+- **The receipt is a CI-unpinnable machine-boundary contract.** Recorded knowingly. If a second
+  participant ever appears (a parser, a persisted run artifact), `load-site-mirror` becomes
+  applicable and should be revisited.
+- **#81 inherits this.** Any later relocation of 5f must carry AC1 as a stated acceptance criterion,
+  or the receipt regresses behind a load the model must also decide to perform.
+
+## Sources & References
+
+### Origin
+- Brainstorm: `docs/brainstorms/2026-08-11-ba-propose-5f-terminal-receipt-brainstorm.md` — carried
+  forward: receipt-always as the success condition (precision stays the residual); the three-line
+  invariant on every path including the offer; the receipt classified as a machine-boundary contract
+  specified to the character with its CI-unpinnability recorded; `/ba-compound` stays invoked from
+  5f; standalone from #81.
+
+### Internal References
+- `skills/ba-propose/SKILL.md:30`, `:572`, `:720-733`, `:735-887`, `:875`, `:876-883`, `:908`
+- `skills/ba-review-plan/SKILL.md:617-660` and `skills/ba-plan/SKILL.md:667-692` — the repo's only
+  hard binding mechanism (a sentinel with a second process waiting on it), and why the receipt cannot
+  be one
+- `skills/ba-review/SKILL.md:213`, `skills/ba-execute/SKILL.md` `resolve-stack-base` — the
+  resolve-early-carry-forward precedent this follows
+- `.claude/agent_docs/prompt-authoring.md:9-23` (trust gradient), `:53-55` (authoring residue),
+  `:59-63` (unevaluable conditions; verification that only proves text exists), `:73-93` (fixture A/B)
+- `docs/solutions/prompt-authoring/2026-07-31-global-instructions-replace-the-step-under-test.md` —
+  "the absence is quiet"
+- `docs/solutions/prompt-authoring/2026-08-08-hoisted-text-invisible-to-dispatched-subagents.md` —
+  a session cannot test the body it loaded
+- `docs/research/2026-07-26-opus5-context-engineering-fit-research.md` — the Every datapoint behind
+  U1's third arm, and the reason U1 precedes U2
+- `#79 (comment, Item 4)` — the STANDARD template mints `#### U1`; this plan mints `### U<n>` per the
+  grammar owner
+
+## Convention Compliance
+
+- [x] U-ID anchor grammar — aligned. `### U<n> — <title>` per the owner in
+  `skills/ba-execute/SKILL.md` (restated `skills/ba-plan/SKILL.md:475`,
+  `references/plan-sections.md:97`), deliberately not the STANDARD template's `#### U1`
+  (`skills/ba-plan/SKILL.md:336`), which is the open defect in `#79 (comment, Item 4)`.
+- [x] `**Code-shape decision:**` label — aligned. `skills/ba-propose/SKILL.md:744` is a borrowed
+  usage, not one of the four pinned mirror sites; the label string stays byte-identical.
+- [x] Trust gradient — aligned. The enum is a machine-boundary contract specified exactly;
+  `interactive_session()` is steering and stays a stated goal.
+- [x] Mirror-site discipline — aligned. All five in-file sites in one unit (AC6); README's two sites
+  in U3; `README.md:145` explicitly excluded; the fan-out cost recorded in Dependencies & Risks.
+- [x] Version bump — aligned. One bump, AC9.
+- [x] `Verify:` minting — aligned. U2's check asserts **ordering** (receipt precedes the offer
+  prompt), not presence, so literals stranded in old 5f prose fail it; U3 anchors to a full phrase
+  unique to the intended sentence and asserts `:145` survives; U1 declares itself commit-tag-only.
+- [x] Experiment before mechanism — aligned with `prompt-authoring.md:73-93` and the Opus-5 evidence;
+  U1 precedes U2 and AC13 gates it.
+- [x] Requirement reconciliation — 13 requirements, all mapped to AC1–AC13. Exclusions all
+  provenance-tagged `inherited` except four `plan-introduced` ones, each recorded above: no Failure
+  Modes row, no `CLAUDE.md` bullet, `HOST=unknown` un-receipted, no assessment timeout.
+- [x] Public-safe — in-repo paths and issue numbers only.
+- [x] Planning skill writes no code — the code-shape block is a labeled shape sketch in a prose spec.
+- [x] Prompt weight — aligned. 5f shrinks from ~150 lines to a dispatch.

--- a/docs/solutions/prompt-authoring/2026-08-11-absence-grep-proves-spelling-not-concept-removed.md
+++ b/docs/solutions/prompt-authoring/2026-08-11-absence-grep-proves-spelling-not-concept-removed.md
@@ -1,0 +1,260 @@
+---
+date: 2026-08-11
+category: prompt-authoring
+problem: retiring a named token from prose and verifying it with `! grep -q '<full token>'` reports green while abbreviated and numeric references to the deleted machinery survive as dangling instructions
+tags: [prompt-authoring, verification, false-green, token-retirement, dangling-reference, acceptance-criteria, fresh-reader-check]
+module: skills/ba-propose/SKILL.md (Step 5e/5f); plan `Verify:` lines; skills/ba-plan/SKILL.md ("Verify: minting rules"); .claude/agent_docs/prompt-authoring.md (review flags)
+symptom: `grep -n '<full token>'` found 8 sites, all 8 were edited, and `! grep -q '<full token>'` exited 0 — green — while the file still carried a 9th site spelling the token short (`` the four `5f:` trace lines ``) and naming the four deleted print sites. Nothing failed. It surfaced only when a dispatched subagent read the file end-to-end and reported the spec self-contradictory
+---
+
+# An absence grep proves one spelling is gone, not that the concept is
+
+## Problem
+
+A change to `skills/ba-propose/SKILL.md` retired a named trace token,
+`5f: capture offer suppressed`. The sweep looked exhaustive and the verification passed, but the
+file shipped describing machinery that no longer existed.
+
+What the author saw, in order:
+
+1. `grep -n '5f: capture offer suppressed' skills/ba-propose/SKILL.md` → **8 sites** (four
+   `print("5f: capture offer suppressed — <reason>")` calls in a pseudo-code sketch, four prose
+   sentences quoting the token).
+2. All 8 edited.
+3. `! grep -q '5f: capture offer suppressed' skills/ba-propose/SKILL.md` → **exit 0. Green.**
+
+A 9th site survived:
+
+> Every `print` in 5f — the four `5f:` trace lines (`ship-url-unresolved` and `non-interactive`
+> above the `try`, `already-captured` and `judged-not-reusable` inside it) …
+
+It specifies four prints that no longer exist, positioned relative to a `try` that no longer
+exists — but spells the token **abbreviated**, as `` `5f:` ``, so the full-token grep could not
+match it. A later check found a **10th** site in the same family: "each of the four SILENCE guards
+below emits exactly one …". Neither contains the string that was grepped for.
+
+In this repo that is not a stale comment. The product *is* prompt text, so a dangling reference is
+a live instruction a future subagent will read and try to execute.
+
+## Investigation
+
+The grep felt sufficient for a specific and recurring reason: the token was *coined* for this
+section, so it read as a unique identifier, and 8 hits is small enough to feel enumerable — you can
+see them all at once, edit them all, and "did I get them all?" collapses into "did the grep return
+zero afterward?". The token's uniqueness was doing double duty: it was both the thing being removed
+and the search key for finding what referenced it.
+
+The author had the file open in context throughout the edit and still missed it. Reading for "is my
+edit correct" is a different pass from reading for "does anything else here still assume the old
+shape", and the green grep had already answered the second question — wrongly.
+
+Detection came from outside the sweep entirely. A dispatched subagent, handed the file and asked to
+*execute* the spec against a fixture, reported the spec internally inconsistent and quoted the
+surviving sentence back.
+
+The failure was also **ratified by the plan**. The implementation plan minted an acceptance
+criterion (AC5, "the retired token appears nowhere in `skills/`") whose `Verify:` line was exactly
+`! grep -q '5f: capture offer suppressed' skills/...`. So the project's own verification step would
+have gone green on a self-contradicting file. The author's blind spot was laundered into the
+artifact and then satisfied.
+
+## Root Cause
+
+The assertion answered a narrower question than the one that mattered.
+
+- **Asserted:** the byte sequence `5f: capture offer suppressed` does not appear in this file.
+- **Cared about:** this file no longer *describes* the deleted mechanism.
+
+The gap between them is every spelling of the reference that is not the canonical one:
+abbreviations (`` `5f:` ``), partial quotes, paraphrase, bare cardinals ("the four trace lines"),
+and — worst — descriptions that never name the token at all but specify its behavior ("above the
+`try`"). A grep for the canonical literal is a **lower bound** on the reference set, and nothing
+tells you how loose a bound it is. Uniqueness of a *string* says nothing about uniqueness of the
+*ways prose can point at it*.
+
+Second half: **prose has no compiler.** Delete a function in code and every call site becomes a
+build error — the language's resolver enumerates the reference set for you, in all its spellings,
+for free. Delete a mechanism from prose and the dangling references stay syntactically perfect.
+The only enumerator is a search you wrote yourself, using the vocabulary you happened to think of.
+
+A third, structural contributor: the edit was **surgical** across 8 scattered sites in a 153-line
+section. Surgical editing puts the burden of completeness on the sweep, because anything the sweep
+misses is by definition still there.
+
+Note also what an absence-only assertion is satisfied by. `! grep -q '<literal>'` goes green if you
+truncate the file, delete the wrong section, or delete the file entirely. It cannot distinguish
+"assertion held" from "subject gone" — a distinction `scripts/check-invariants.mjs` already takes
+seriously elsewhere (`load-site-mirror` reads UNKNOWN, not PASS, below two blocks; `rubric-mirror`
+reads UNKNOWN when a mirror file has no `Task` block).
+
+## Solution
+
+Two changes, both general.
+
+**1. Replace the region wholesale instead of editing N scattered sites.** The real fix rewrote the
+whole section — 153 lines down to 69 — rather than surgically removing 8 tokens. That is a
+*structural* guarantee, not diligence: a stranded reference is a **survival phenomenon**, requiring
+text you never read to persist across the edit. Wholesale replacement makes persistence impossible,
+because every surviving line was authored against the new design. It is also what silently removed
+the 10th site nobody had found yet.
+
+**2. Assert a surviving positive invariant plus ordering, not only absence.** The strengthened
+`Verify:` line that shipped:
+
+```bash
+grep -q 'capture: {decision}' skills/ba-propose/SKILL.md \
+  && ! grep -q '5f: capture offer suppressed' skills/ba-propose/SKILL.md \
+  && ! grep -q 'gates on its own predicate' skills/ba-propose/SKILL.md \
+  && awk '/capture: \{decision\}/{r=NR} /Document this learning/{p=NR} END{exit !(r && p && r < p)}' \
+       skills/ba-propose/SKILL.md
+```
+
+The `awk` clause does work no absence-grep can do: it asserts the new receipt line appears
+**before** the offer prompt. That is a relational property of the new design, and text stranded
+from the old design cannot satisfy it — either the anchor is missing or it is in the wrong place.
+An absence-grep is satisfied by a file that says nothing; a positive invariant is only satisfied by
+a file that says the right thing.
+
+### The general recipe for retiring a named thing from prose
+
+- **Assert what replaced it,** not only that it is gone — at least one `grep -q` for a token that
+  exists only in the new design.
+- **Assert an ordering or containment relation** between two new anchors. Ordering is the cheapest
+  structural property to check and the hardest to satisfy accidentally.
+- **Keep the absence-greps, but plural** — the canonical literal *and* every distinctive phrase
+  from the old prose.
+- **Sweep with a pattern list, not one token.** This is what actually produced confidence here,
+  and every count is expected to be `0`:
+
+  ```bash
+  for pat in 'gates on its own predicate' 'required terminal step' 'try` boundary is unchanged' \
+             'microseconds earlier' 'Print failure model' 'infallible' \
+             'Silence preconditions' 'correct silence'; do
+    printf '%-40s ' "$pat"; grep -c "$pat" skills/ba-propose/SKILL.md
+  done
+  ```
+
+  Build the list by reading the **deleted text** for its distinctive vocabulary — coined phrases,
+  abbreviations, structural landmarks like `try` — not by reasoning forward from the token name.
+
+- **Grep bare cardinals in the touched file.** Prose numerals are co-references that share no
+  characters with the token, which is exactly how the 9th site hid. Verified against the
+  pre-change revision, this finds it:
+
+  ```bash
+  git show origin/main:skills/ba-propose/SKILL.md | grep -niE '\bfour\b'
+  ```
+
+  On the real file that returned 4 hits: the 9th site, the 10th site, and two unrelated
+  "four-way decision" mentions. A ~50% false-positive rate on a 4-hit list is a trivial eyeball
+  cost and it is the only tactic here that would have caught the miss at sweep time.
+
+  Do **not** reach for a cleverer regex. A narrower numeral-plus-noun pattern was tried against
+  this same file and returned **zero** hits — precision bought nothing and cost the finding.
+
+## Prevention
+
+**Phrase the criterion over what survives.** `ba-plan`'s minting rule (d) already requires a
+`Verify:` to assert wiring for an addition; the deletion-shaped corollary is that **the retired
+token must not be the subject of the assertion at all.** If the retired string appears in your
+`Verify:` line and nothing else does, the check is almost certainly wrong.
+
+**Rehearse falsifiability in the deletion flavour.** `ba-plan` already asks "what broken-but-
+plausible state would still pass?". For a retirement unit the answer is always the same and belongs
+in the plan verbatim: *"the section is gone, and a neighbouring sentence still refers to it in
+abbreviated form or by count."* Then name which check fails under that state. If the answer is
+"none", the `Verify:` is not done.
+
+**Decide surgical vs wholesale at plan time, by premise.** Surgical when the section's organizing
+premise survives and you are changing a leaf fact. Wholesale when the change invalidates the
+premise the section is *organized around*. The readable tell: **if removing a token requires
+touching most paragraphs of a section, you are already paying replacement's cost without buying its
+safety.** Count grep hits per section — many hits get rewritten, one gets edited.
+
+Wholesale replacement's own cost, and where it bites in this repo: it discards machine-boundary
+literals — sentinels, exact anchors, byte-identical mirrored load-site blocks. Extract the contract
+literals from the old section into an explicit list and re-assert each in the new one. It is
+cheapest where CI pins those literals (`sentinels`, `rubric-mirror`, `load-site-mirror` catch a
+dropped one) and most dangerous where it does not — `CLAUDE.md`'s hand-maintained U-ID / stack-base
+grid, the reviewer counts, the `**Code-shape decision:**` label.
+
+**The fresh-reader check.** Hand a subagent **only the post-change file** — not the diff, not the
+plan, not the retired token's name — and ask it to inventory rather than approve:
+
+> Read this file. List every mechanism, step, or value it says exists. For each, cite the line that
+> mentions it and the line that defines it. Then list anything mentioned but never defined, and any
+> count or enumeration you cannot verify from the file itself.
+
+Why it worked, precisely: the author reads "the four `5f:` trace lines" and their own memory
+silently supplies the referent, so the sentence parses as true — the check degenerates into
+confirming an expectation. A reader with no memory of the intended change **has no referent to
+supply**, so the same sentence surfaces as an unanswerable question. The asymmetry is *absence of
+expectation*, not superior care. Which means the technique **fails the moment you brief the
+reader**: telling it "I retired X, check for leftovers" restores the expectation and converts the
+fresh reader into a grep with extra steps.
+
+Limits, plainly: it is nondeterministic, unrepeatable, and not a regression detector — it catches
+this instance and prevents nothing next time. It confabulates, so treat its output as questions to
+adjudicate against the file, not findings. And it only sees the file boundary you give it; a
+reference stranded in `README.md` is invisible to a reader handed one `SKILL.md`.
+
+**Review the acceptance criterion, not only the change.** In `/ba-review-plan`, treat a `Verify:`
+line whose assertion is the *absence* of a string as a finding by default, with one exception: a
+machine-boundary literal that CI can also blocklist. Otherwise demand a positive-invariant
+restatement. A related failure from the same run reinforces this: the plan's pre-committed A/B
+decision rule was also unsatisfiable as written, because it required a signal on all four fixtures
+while one fixture's ground truth was that signal's *absence*. Plan-time criteria get the same
+scrutiny as the change — the author's blind spot propagates into them.
+
+**What CI cannot pin here.** A general dangling-reference check for prose cannot exist: it would
+need the set of live mechanisms in machine-readable form, and that set has no source of truth — it
+*is* the prose. No regex distinguishes "the four `5f:` trace lines" written while the machinery
+lived from the same sentence after it died. Do not plan one. Specifically, adding the retired token
+to a blocklist would be the same presence-only grep this repo already classifies as a false-green,
+merely negated — and it would still have missed the 9th site, which never contained the literal.
+
+`scripts/check-invariants.mjs` already carries `retired-invocations`, a blocklist for a retired
+spelling. Extend it only when the retired token is a **machine-boundary literal** with a single
+canonical spelling that two processes had to agree on, and only as a **ratchet against
+reintroduction** — never as the acceptance criterion for the removal.
+
+**Design rule for any new check:** if the check's subject can be deleted, the check must report
+three states — held / violated / subject-absent. Every `! grep -q` collapses the third into the
+first.
+
+**What generalizes past prompt repos** (any prose-as-product — docs, specs, config templates,
+migration guides, runbooks): positive-invariant verification over absence; cardinal-numeral sweeps;
+premise-death as the trigger for wholesale replacement; the fresh-reader check and the rule that
+briefing destroys it; harvesting the referent set from the pre-change revision; three-state checks;
+and reviewing the acceptance criterion. Specific to this repo: the `retired-invocations` ratchet,
+the unpinned mirror obligations that make wholesale replacement riskier than the CI-pinned literals
+suggest, and the fact that subagent dispatch is nearly free here — which is what makes the
+fresh-reader check a default rather than a luxury.
+
+## Related Documentation
+
+The absence direction is new; two siblings cover the **presence** direction, where a variant
+spelling is the thing to fail on rather than a thing a check can miss.
+
+- [`2026-08-09-per-dispatch-block-ci-catches-template-drift.md`](2026-08-09-per-dispatch-block-ci-catches-template-drift.md)
+  — **same failure family, closest match.** A `rubric-mirror` check named the right literal in the
+  right file and still passed, because a per-file existence test over a literal that legitimately
+  appears N times is satisfied by whichever copy is still correct. That is the presence-direction
+  twin of this entry's defect, and its "a prose claim is unpinned by default" rule is what this
+  entry inverts into "a claim of *removal* is unpinned by default."
+- [`2026-08-08-hoisted-text-invisible-to-dispatched-subagents.md`](2026-08-08-hoisted-text-invisible-to-dispatched-subagents.md)
+  — near-sibling, and the prior art on removal-shaped acceptance criteria: *"Any AC phrased as 'X
+  does not appear in Y' invites the implementation that deletes X and stops."* It reasons about the
+  risk that **too much** got deleted; this entry is the complement, where too little did and the
+  check could not tell. Also owns the "loose locator, byte-exact assertion" pattern.
+- [`2026-07-31-probe-instrument-validation-false-zeros.md`](2026-07-31-probe-instrument-validation-false-zeros.md)
+  — same family at the methodology level. Its governing rule generalizes this entry's specific
+  lesson: *before trusting any zero, prove the instrument can produce a non-zero.* The green
+  `! grep -q` was never shown capable of failing on the surviving spelling.
+- [`2026-08-02-path-heuristics-misread-prompt-repo-filenames.md`](2026-08-02-path-heuristics-misread-prompt-repo-filenames.md)
+  — adjacent, two concrete hooks: the nearest prior art for CI-pinning a literal token list in this
+  repo (including an inverse arm that FAILs when *zero* paths match — the missing guard shape for a
+  removal grep), and the only other entry whose module is `skills/ba-propose/SKILL.md`.
+- [`2026-07-31-global-instructions-replace-the-step-under-test.md`](2026-07-31-global-instructions-replace-the-step-under-test.md)
+  — adjacent; source of the idiom *"the absence is quiet."* This entry extends it: a token that did
+  not get deleted is quiet too, if you only asked about one of its spellings.

--- a/skills/ba-propose/SKILL.md
+++ b/skills/ba-propose/SKILL.md
@@ -27,7 +27,7 @@ Recognized flags:
 
 **`REVIEW_MODE`** — a run-local orchestrator variable (alongside `ACTION`, `HOST`; it never enters `CompositionInputs`) that gates the Step 0b edit-only confirm and the Step 4 Apply menu (see U2 in those steps). Resolved as an OR, not an AND: `REVIEW_MODE = (--review present) OR (BA_PROPOSE_REVIEW is set to a non-empty, non-"0" value)`. Either signal alone is sufficient — a flag or an env var must never be silently ignored, since silently dropping an explicit safety opt-in on an apply-by-default command is the worst failure mode. `BA_PROPOSE_REVIEW=0` and an empty value are treated as unset. `BA_PROPOSE_REVIEW=1` set once in a shell profile is the persistent equivalent of always passing `--review`.
 
-**`REVIEW_MODE` touches exactly two confirmations** — the Step 0b edit-only confirm and the Step 4 `Apply?` menu — and nothing else. The Step 5b hook-failure surface-and-exit (never `--no-verify`), the Step 5c non-fast-forward `--force-with-lease` confirmation, and the `describe_only` short-circuit are unaffected by `REVIEW_MODE` regardless of how it resolves. The **Step 5f ship-time capture offer** is likewise **not** a `REVIEW_MODE`-gated confirmation: it is a non-blocking, mode-independent **required terminal step** of Step 5 (Step 5 is not complete until 5f has *run* — not *succeeded*) that fires identically with or without `--review` — it runs after the ship has already succeeded, gates on its own predicate (5e printed `✓ <url>` and `ACTION == commit_push_create`), and can never change the ship's exit status.
+**`REVIEW_MODE` touches exactly two confirmations** — the Step 0b edit-only confirm and the Step 4 `Apply?` menu — and nothing else. The Step 5b hook-failure surface-and-exit (never `--no-verify`), the Step 5c non-fast-forward `--force-with-lease` confirmation, and the `describe_only` short-circuit are unaffected by `REVIEW_MODE` regardless of how it resolves. The **Step 5f capture dispatch** is likewise **not** a `REVIEW_MODE`-gated confirmation: it is a non-blocking, mode-independent consumer of the capture disposition that 5e resolved and printed, firing identically with or without `--review` — it runs after the ship has already succeeded and can never change the ship's exit status. **Step 5's completion invariant is that the receipt printed**, not that 5f ran: the disposition rides 5e's contiguous block (see 5e for the closed six-value enum), so a dispatch that never fires is still observable.
 
 Note: there is no explicit `--describe-update` flag. Step 0b resolves a single `ACTION` enum (one of `commit_push_create` / `commit_push_edit` / `edit_only` / `describe_only`) from the args and the branch state; Steps 5a-5d dispatch on `ACTION`. The "nothing to push + open PR" case resolves to `edit_only` via a single confirmation prompt in 0b (skipped by default — see `REVIEW_MODE`). One arg flag, one `ACTION` enum, no cross-product of mode + skip flags.
 
@@ -569,7 +569,7 @@ Step 5 dispatches on the single `ACTION` value resolved in Step 0b. The `HOST=un
 
 | `ACTION` | Actions |
 |---|---|
-| `commit_push_create` | 5a (stage) → 5b (commit) → 5c (push) → 5d (create PR/MR) → 5e (output) → 5f (capture offer) |
+| `commit_push_create` | 5a (stage) → 5b (commit) → 5c (push) → 5d (create PR/MR) → 5e (output: the three-line receipt, whose line 3 is the capture disposition) → 5f (dispatch on it) |
 | `commit_push_edit` | 5a (stage) → 5b (commit) → 5c (push) → 5d (edit existing PR/MR) |
 | `edit_only` | 5d only (edit existing PR/MR description; no commit, no push) |
 | `describe_only` | Print body to stdout; exit zero. |
@@ -717,69 +717,126 @@ glab mr update "$OPEN_PR_URL" \
 - Print: "Push succeeded; PR/MR creation failed. Re-run `/ba-propose` after fixing the platform issue — commits are already pushed, so staging/commit/push are no-ops, and Step 5d will create the PR."
 - Exit non-zero. Do not retry automatically. Do not rewind the push.
 
-### 5e. Output
+### 5e. Output — the terminal receipt
 
-On success, print the new PR/MR URL captured in 5d (`CREATED_PR_URL`):
+On success, print **one contiguous block**. Line 1 is the success line, line 2 the PR/MR URL captured
+in 5d (`CREATED_PR_URL`), line 3 the **capture disposition** resolved here:
 
 ```
 ✓ <title>
   $CREATED_PR_URL
+  capture: <value>
 ```
+
+**The `<value>` set is CLOSED — exactly these six literals:** `judged-reusable`,
+`suppressed — ship-url-unresolved`, `suppressed — non-interactive`, `suppressed — already-captured`,
+`suppressed — judged-not-reusable`, `unavailable`.
+
+**This section is the canonical site for the enum.** It is restated in the `REVIEW_MODE`-touches-two-
+confirmations paragraph under Arguments, in the Step 5 action table, in 5f's dispatch paragraph, in
+the **Code-shape decision** block below, and in `README.md`'s `/ba-compound` and `/ba-propose` feature
+lists. Update them together — **no CI check pins them**, and a literal grep for a retired token
+reports green while prose elsewhere still describes the deleted machinery.
 
 **Unparseable-URL guard.** If the create call in 5d exits 0 but `CREATED_PR_URL` is empty or not a
-URL (a transient CLI/output-format hiccup), print the success line without a URL and treat the URL as
-absent for the offer: Step 5f does not fire the offer on a placeholder — instead it emits a one-line
-`5f: capture offer suppressed — ship-url-unresolved` trace. A successful `commit_push_create` ship
-that stayed silent must remain observable, never a byte-identical skip.
+URL (a transient CLI/output-format hiccup), omit the URL line and print
+`  capture: suppressed — ship-url-unresolved` as line 2 of a two-line receipt. That two-line form is
+the one legitimate sub-three-line receipt, and it is distinguished from a partial print by the
+`capture:` line being **present** — a genuine partial print emits the `✓` line alone. A successful
+`commit_push_create` ship that stayed silent must remain observable, never a byte-identical skip.
+**This observability standard scopes to routes that reach 5e**; routes that exit before it
+(`HOST=unknown`, any pre-5e failure exit, and the three edit paths) emit no receipt fragment at all.
 
-### 5f. Ship-time capture offer
-
-**A required terminal step of Step 5** — Step 5 is not complete until 5f has **run** (not
-"succeeded": a run-but-failed 5f still leaves the ship successful). Physically last in Step 5, it
-runs only after 5e has printed `✓ <url>`. Non-blocking and mode-independent, not a confirmation
-gate: *not* governed by `REVIEW_MODE`, fires identically with or without `--review`, and never
-feeds `CompositionInputs`. The ship has already succeeded before this block runs, and nothing here
-can change its exit status.
-
-**Code-shape decision:** the gate/silence/offer control flow is the load-bearing decision of this
-change, and re-deriving it from prose alone plausibly produces a *wrong* structure (firing on edit
-paths, tracing the unreachable enum guard, folding the reachable empty-URL case into the traceless
-bucket, or letting a compound failure taint the ship). The exact predicate + ordering + per-path
-trace is fixed by this sketch; the failure-isolation boundary is drawn around the `try` body
-(assessment + prompt + `/ba-compound` invocation), not just the `/ba-compound` call — the guards
-above the `try` cannot breach the exit-status guarantee (their `print`s are infallible per the
-**Print failure model** below). It is a shape sketch, not literal command text — the file is a prose
-spec — and the paragraphs below elaborate each branch.
+**Code-shape decision:** the resolver's ordering is the load-bearing decision and re-deriving it from
+prose plausibly produces a wrong structure — URL validation inside the exception boundary (making
+`ship-url-unresolved` unreachable and `unavailable` win), the interactivity check after the
+assessment (paying for a judgment that cannot be offered), or `judged-reusable` restored as a
+forward-looking promise. The enum literals are the contract and are not paraphrased. It is a shape
+sketch, not literal command text — the file is a prose spec — and the paragraphs below elaborate each
+branch.
 
 ```
-# 5f. Ship-time capture offer — runs only after 5e printed "✓ <url>".
-# Trace invariant: each of the four SILENCE guards below emits exactly one
-# `5f: capture offer suppressed — <reason>` line, then returns. The offer path is exempt from that
-# count — it traces via the AskUserQuestion itself, plus one bounded outcome line on accept.
-# Genuinely-unreachable actions (the first guard) stay traceless. The try/except isolates the
-# assessment, prompt, and /ba-compound invocation: any exception there degrades to the "PR is live"
-# message. Every print here is infallible (see the print-failure model below), so nothing —
-# including the two guards above the try — can change the ship's exit status.
-if ACTION != commit_push_create:   # CREATED_PR_URL captured in 5d, printed by 5e
-    return                      # unreachable action (edit_only / commit_push_edit / describe_only)
-                                # → traceless (HOST=unknown keeps this ACTION but exits in 5d first)
-if not CREATED_PR_URL:          # reachable: successful create, 5e could not parse the URL (5e guard)
-    print("5f: capture offer suppressed — ship-url-unresolved")
-    return
-if not interactive_session():   # default-mode propose may run scripted/headless
-    print("5f: capture offer suppressed — non-interactive")   # a static stdout write cannot hang
-    return                      # no answerer for the offer → silent, never hang
-try:
-    if solutions:               # Step 2c non-empty → already documented & in the PR
-        print("5f: capture offer suppressed — already-captured")
-        return
-    if not assess_reusable_learning(deviation_trailers, conversation_arc,
-                                    commit_type, risk, proof):
-        print("5f: capture offer suppressed — judged-not-reusable")   # negative OR uncertain
-        return                  # lean-silent = precision
-    answer = AskUserQuestion("Document this learning?", options=[Yes, No])  # the offer IS its trace
+# 5e. Output — one contiguous receipt. Line 3's value set is CLOSED (six literals).
+# CANONICAL SITE for the enum. Restated in the REVIEW_MODE paragraph, the Step 5 action table,
+# 5f's dispatch paragraph, and README's two feature lists — update together; no CI check pins this.
+print(f"✓ {title}")
+if is_url(CREATED_PR_URL): print(f"  {CREATED_PR_URL}")
+
+# Validity is judged HERE — empty OR malformed — outside the resolver's exception boundary, and it
+# RETURNS before the try, so ship-url-unresolved and unavailable can never both fire.
+if not is_url(CREATED_PR_URL):
+    print("  capture: suppressed — ship-url-unresolved"); goto 5f_dispatch(decision=None)
+
+try:                                     # resolver boundary #1 → degrades to `unavailable`
+    if not interactive_session():         # model-judged; deliberately unspecified (steering)
+        decision = "suppressed — non-interactive"
+    elif solutions:                       # 2c: entries the user ACCEPTED, not files on disk
+        decision = "suppressed — already-captured"
+    elif not assess_reusable_learning(deviation_trailers, conversation_arc,
+                                      commit_type, risk, proof):
+        decision = "suppressed — judged-not-reusable"   # negative OR uncertain → lean-silent
+    else:
+        decision = "judged-reusable"      # a DECISION, not a promise: no later failure falsifies it
+except Exception:
+    decision = "unavailable"              # exit status was fixed by 5c/5d; nothing here alters it
+print(f"  capture: {decision}")
+# 5f dispatch: judged-reusable → fire the offer. Every other value → no-op.
+```
+
+**`interactive_session()` is deliberately model-judged.** Per the trust gradient this is steering,
+not a machine boundary: state the goal — default-mode propose may run scripted/headless, and there is
+then no answerer for an offer — and stop. It is **not** a dead branch.
+
+**Line 3 states a decision already made, never a prediction.** `judged-reusable` is the resolver's
+verdict, not a promise that the offer will be answered or that `/ba-compound` will succeed — so no
+later failure of the `AskUserQuestion` or the invoke can contradict a receipt already flushed.
+
+**Exit status.** A resolver exception prints `capture: unavailable`, still prints the `✓` line, and
+leaves the ship's exit status zero. The ground is that **exit status is already determined before 5e
+runs at all** — 5c's push and 5d's create decide it, and 5e/5f contain no statement that can alter
+it.
+
+**Assessment (best-effort, blended, read-only).** Not a rigid rubric. Read already-materialized
+orchestrator state plus the conversation; mutate nothing. Weigh:
+
+- (a) `deviation_trailers` from Step 2f — *strongest* signal ("reality diverged from the plan,
+  here's why").
+- (b) A problem → investigation → fix arc visible in the conversation.
+- (c) Commit type / motivation — a `fix:` for a gotcha/workaround weighs positive; a clean `feat:`
+  or a docs/config-only change weighs toward routine.
+- (d) Lightly: `risk` (2h), `proof` (2e), `sensitive_paths_touched` (2g).
+
+Lean-silent: a genuinely ambiguous change (e.g. a `fix:` with no deviation trailer and no clear
+problem→fix arc) is judged **uncertain** and resolves to `suppressed — judged-not-reusable`.
+Precision over recall.
+
+**`already-captured` is keyed on a user choice, not a fact.** `solutions` holds the entries the user
+*accepted* at 2c; choosing "Skip all" yields an empty tuple even when `docs/solutions/` files ride
+the PR.
+
+**Ordering.** Every assessment input is settled well before 5e: `deviation_trailers` (2f), `risk`
+(2h), `proof` (2e), `sensitive_paths_touched` (2g), `solutions` (2c), commit type (Step 3), and the
+conversation arc (ambient). The resolver now sits between PR creation and the user seeing the URL, so
+a slow assessment delays the printed URL; the `try` guards a *thrown* exception, not a hung one.
+There is no timeout — accepted, since the assessment reads only already-materialized state.
+
+### 5f. Capture dispatch
+
+A **consumer** of the disposition 5e resolved and printed — 5e owns the predicate, 5f owns only the
+offer. **One branch:** on `judged-reusable`, fire the offer. **Every other value — including the
+unresolved-URL route's — is a no-op**, because 5e already printed the trace. Non-blocking and
+mode-independent, not a confirmation gate: *not* governed by `REVIEW_MODE`, fires identically with or
+without `--review`, and never feeds `CompositionInputs`. The ship has already succeeded before this
+block runs, and nothing here can change its exit status.
+
+```
+# 5f. Capture dispatch — consumes 5e's `decision`. One branch, not five.
+if decision != "judged-reusable":
+    return                      # 5e already printed the disposition; nothing to add
+try:                            # isolation boundary #2 → degrades to "PR is live; capture failed"
+    answer = AskUserQuestion("Document this learning?", options=[Yes, No])
     if answer != Yes:
-        return                  # decline → no closing line; offer already fired (not a silent path)
+        return                  # decline → no closing line; success already printed
     result = run("/ba-compound", context_hint=seed(motivation, deviation_trailers, risk, proof, diff_summary))
     # NOTE: compound prints its OWN completion summary AND its own Step 4 menu —
     # a possible second insufficient-context prompt is also compound's, not propose's.
@@ -794,56 +851,10 @@ except Exception:
     print("PR is live; capture failed — run /ba-compound manually.")   # ship stays successful
 ```
 
-**Gate — split into two guards.** (1) `ACTION != commit_push_create` → **traceless** return: 5f is
-not meant to run for `describe_only` (exits at Step 4) or `edit_only`/`commit_push_edit` (edit paths,
-no new PR). Cases that keep `ACTION == commit_push_create` but exit *before* 5f — `HOST=unknown`
-(5d exits zero) and any pre-5f failure exit (5b/5c/5d) — never reach here at all, so they are
-traceless by construction, not by this guard. (2) On `commit_push_create` that does reach 5f, a
-**non-empty `CREATED_PR_URL`** is still required to fire the offer, but an empty one is now a
-**reachable, traced** silence (`ship-url-unresolved`) rather than a traceless skip — a successful
-ship that stays silent must remain observable. Binding the offer to the URL (not the word "create")
-still excludes the no-URL cases from *firing*; the split just distinguishes "never meant to run"
-(traceless) from "ran, chose silence" (traced).
-
-**Silence preconditions (any true → emit exactly one `5f: capture offer suppressed — <reason>` line, then return — no offer). Listed in check order:**
-
-1. **Unparseable ship URL** — `commit_push_create` succeeded but `CREATED_PR_URL` is empty (5e could
-   not parse it). Reason token `ship-url-unresolved`. *Checked first*, right after the unreachable-
-   action guard — a successful ship that can't fire the offer must still trace, not skip silently.
-2. **Non-interactive session** (scripted/headless, no answerer). Reason token `non-interactive`. The
-   offer adds the first `AskUserQuestion` to the default (`--review`-absent) flow, which is
-   prompt-free/scriptable today, so a missing interactive answerer is a silence precondition, never
-   a hang — and the trace is a plain stdout write, which cannot hang a headless session.
-3. **Already captured** — `solutions` (Step 2c) is non-empty. Reason token `already-captured`. The
-   learning is already documented and rode this very PR; a high-precision negative that costs
-   nothing.
-4. **Negative or uncertain judgment** — the assessment did not land clearly positive. Reason token
-   `judged-not-reusable` — one honest label covering both the negative and the lean-silent-uncertain
-   outcomes (the assessment stays a bool; it is not split into a confidence result). Lean
-   **silent**: precision over recall.
-
-Items 1–2 are the two guards above the `try`; items 3–4 sit inside it. Genuinely-unreachable actions
-(the first gate guard, plus `HOST=unknown` and any pre-5f exit) emit nothing.
-
-**Assessment (best-effort, blended, read-only).** Not a rigid rubric. Read already-materialized
-orchestrator state plus the conversation; mutate nothing. Weigh:
-
-- (a) `deviation_trailers` from Step 2f — *strongest* signal ("reality diverged from the plan,
-  here's why").
-- (b) A problem → investigation → fix arc visible in the conversation.
-- (c) Commit type / motivation — a `fix:` for a gotcha/workaround weighs positive; a clean `feat:`
-  or a docs/config-only change weighs toward routine.
-- (d) Lightly: `risk` (2h), `proof` (2e), `sensitive_paths_touched` (2g).
-
-Lean-silent: a genuinely ambiguous change (e.g. a `fix:` with no deviation trailer and no clear
-problem→fix arc) is judged **uncertain** and stays silent.
-
-**Offer (only on a positive judgment).** One 2-option `AskUserQuestion` — "Document this
-learning?" — Yes / No, with **No** as the recommended-neutral default (one keystroke to decline).
-The `AskUserQuestion` **is** this path's trace — the offer path emits no `5f: …suppressed` line (it
-wasn't suppressed), and a decline needs no closing line (the offer already fired, so it is not a
-silent path). On accept, exactly one bounded outcome line follows (`captured` | `no doc written`);
-`/ba-compound`'s own summary/menu are compound's, not 5f's.
+**Offer (only on `judged-reusable`).** One 2-option `AskUserQuestion` — "Document this learning?" —
+Yes / No, with **No** as the recommended-neutral default (one keystroke to decline). The offer is
+**not** its own trace: 5e's `capture:` line already recorded the disposition before the widget fired,
+so the disposition is observable whether or not the offer is answered.
 
 - **Decline** → proceed to normal completion. Nothing remains to print; success already printed.
 - **Accept** → invoke `/ba-compound` on its explicit (proceed-directly) path, passing a **seeded
@@ -868,23 +879,16 @@ absence-of-exception alone:
 - **Soft-fail (no doc written)** → say so and point at the escape hatch ("no doc written — run
   `/ba-compound` manually when you have more context"); do **not** print "captured".
 
-**Failure isolation (the `try` body — assessment, prompt, and invoke).** The ship is already
-reported successful; nothing in 5f may change its exit status. Any exception *inside the `try`* — in
-the assessment, in the `AskUserQuestion` itself, or in the `/ba-compound` invocation — degrades
-identically to a single note and leaves the ship successful: "PR is live; capture failed — run
-`/ba-compound` manually." The `try` boundary is unchanged by the trace additions: it still wraps
-only the assessment, prompt, and invoke — no `print` site needs to move. **Print failure model
-(all trace/outcome sites).** Every `print` in 5f — the four `5f:` trace lines (`ship-url-unresolved`
-and `non-interactive` above the `try`, `already-captured` and `judged-not-reusable` inside it) and
-the accept-path outcome lines — is treated as **infallible**: stdout is assumed healthy, since 5e's
-`✓ <url>` already wrote to it microseconds earlier, so no `print` here can be the first to break.
-That is why the two above-`try` guards need no wrapping (an unwrapped `print` that cannot fail cannot
-breach the "never changes exit status" guarantee) and why the in-`try` traces need no special catch
-(a stray relabel to "capture failed" is unreachable for the same reason).
-Each reachable silent path now leaves a one-line reasoned trace, so a **skip** (which prints
-nothing) is distinguishable from a **correct silence**. Manual `/ba-compound` remains the escape
-hatch for a **false-negative judgment** — a `judged-not-reusable` trace that should have been an
-offer — the assessment's precision, not its observability, is the accepted residual.
+**Failure isolation (the `try` body — prompt and invoke).** The ship is already reported successful;
+nothing in 5f may change its exit status. Any exception inside the `try` — in the `AskUserQuestion`
+itself or in the `/ba-compound` invocation — degrades identically to a single note and leaves the ship
+successful: "PR is live; capture failed — run `/ba-compound` manually." The boundary wraps the prompt
+and the invoke only; the assessment now sits inside 5e's own boundary, which degrades to
+`capture: unavailable`. Neither boundary can breach the exit-status guarantee, for the reason 5e
+states: **exit status is fixed by 5c's push and 5d's create before 5e runs**, so no print in 5e or 5f
+can alter it. Manual `/ba-compound` remains the escape hatch for a **false-negative judgment** — a
+`suppressed — judged-not-reusable` receipt that should have been an offer — the assessment's
+precision, not its observability, is the accepted residual.
 
 ## Failure Modes
 

--- a/skills/ba-propose/SKILL.md
+++ b/skills/ba-propose/SKILL.md
@@ -569,7 +569,7 @@ Step 5 dispatches on the single `ACTION` value resolved in Step 0b. The `HOST=un
 
 | `ACTION` | Actions |
 |---|---|
-| `commit_push_create` | 5a (stage) → 5b (commit) → 5c (push) → 5d (create PR/MR) → 5e (output: the three-line receipt, whose line 3 is the capture disposition) → 5f (dispatch on it) |
+| `commit_push_create` | 5a (stage) → 5b (commit) → 5c (push) → 5d (create PR/MR) → 5e (output: the receipt — three lines, or two when the URL is unresolved — whose last line is the capture disposition) → 5f (dispatch on it) |
 | `commit_push_edit` | 5a (stage) → 5b (commit) → 5c (push) → 5d (edit existing PR/MR) |
 | `edit_only` | 5d only (edit existing PR/MR description; no commit, no push) |
 | `describe_only` | Print body to stdout; exit zero. |
@@ -732,11 +732,14 @@ in 5d (`CREATED_PR_URL`), line 3 the **capture disposition** resolved here:
 `suppressed — ship-url-unresolved`, `suppressed — non-interactive`, `suppressed — already-captured`,
 `suppressed — judged-not-reusable`, `unavailable`.
 
-**This section is the canonical site for the enum.** It is restated in the `REVIEW_MODE`-touches-two-
-confirmations paragraph under Arguments, in the Step 5 action table, in 5f's dispatch paragraph, in
-the **Code-shape decision** block below, and in `README.md`'s `/ba-compound` and `/ba-propose` feature
-lists. Update them together — **no CI check pins them**, and a literal grep for a retired token
-reports green while prose elsewhere still describes the deleted machinery.
+**This section is the canonical site for the enum.** Two other sites **restate the literals** and must
+be updated with it: 5f's dispatch paragraph, and `README.md`'s `/ba-compound` and `/ba-propose` feature
+lists — README's is the highest-drift site, since it paraphrases every disposition in prose rather than
+citing them. The `REVIEW_MODE`-touches-two-confirmations paragraph under Arguments, the Step 5 action
+table, and the **Code-shape decision** block below are **pointers, not copies** — they name at most one
+literal and defer here, so a rename does not oblige an edit there. **No CI check pins any of this**, and
+a literal grep for a retired token reports green while prose elsewhere still describes the deleted
+machinery.
 
 **Unparseable-URL guard.** If the create call in 5d exits 0 but `CREATED_PR_URL` is empty or not a
 URL (a transient CLI/output-format hiccup), omit the URL line and print
@@ -756,16 +759,14 @@ sketch, not literal command text — the file is a prose spec — and the paragr
 branch.
 
 ```
-# 5e. Output — one contiguous receipt. Line 3's value set is CLOSED (six literals).
-# CANONICAL SITE for the enum. Restated in the REVIEW_MODE paragraph, the Step 5 action table,
-# 5f's dispatch paragraph, and README's two feature lists — update together; no CI check pins this.
+# 5e. Output — one contiguous receipt. Line 3's value set is CLOSED (six literals; see above).
 print(f"✓ {title}")
 if is_url(CREATED_PR_URL): print(f"  {CREATED_PR_URL}")
 
 # Validity is judged HERE — empty OR malformed — outside the resolver's exception boundary, and it
 # RETURNS before the try, so ship-url-unresolved and unavailable can never both fire.
 if not is_url(CREATED_PR_URL):
-    print("  capture: suppressed — ship-url-unresolved"); goto 5f_dispatch(decision=None)
+    print("  capture: suppressed — ship-url-unresolved"); decision = None; return   # → 5f no-ops
 
 try:                                     # resolver boundary #1 → degrades to `unavailable`
     if not interactive_session():         # model-judged; deliberately unspecified (steering)
@@ -816,8 +817,9 @@ the PR.
 
 **Ordering.** Every assessment input is settled well before 5e: `deviation_trailers` (2f), `risk`
 (2h), `proof` (2e), `sensitive_paths_touched` (2g), `solutions` (2c), commit type (Step 3), and the
-conversation arc (ambient). The resolver now sits between PR creation and the user seeing the URL, so
-a slow assessment delays the printed URL; the `try` guards a *thrown* exception, not a hung one.
+conversation arc (ambient). The resolver runs *after* the `✓` and URL lines are printed, so a slow
+assessment delays only the `capture:` line, never the URL; the `try` guards a *thrown* exception, not a
+hung one.
 There is no timeout — accepted, since the assessment reads only already-materialized state.
 
 ### 5f. Capture dispatch

--- a/skills/ba-review/SKILL.md
+++ b/skills/ba-review/SKILL.md
@@ -341,7 +341,7 @@ Reviewer selection — <T> candidates (<S> ✓ selected, <A> ○ set aside)
 ○ deep-module-reviewer — overlaps with architecture-reviewer here; architecture covers the structure
 ○ complexity-reviewer — diff is small and linear; no cognitive-load surface
 ○ comment-quality-reviewer — no doc comments added or modified; changed bodies carry no inline comments
-○ dragon-test-reviewer (agent) — overlaps with test-coverage-reviewer on this diff
+○ e2e-test-reviewer (agent) — overlaps with test-coverage-reviewer on this diff
 ```
 
 **No elision.** The real guarantee is the **enumeration**: every candidate appears on its own line
@@ -460,7 +460,7 @@ If no issues at a severity, write `None` under that heading. Do not invent place
 
 For each selected reviewer, dispatch a fresh subagent using the Agent tool — regardless of whether it is an agent or a skill. Every reviewer must run in its own isolated context.
 
-**Built-in vs external dispatch:** built-in plugin reviewers use `subagent_type: dev-workflow:<name>` (e.g. `dev-workflow:security-reviewer`). The selection ledger shows bare display names for readability; the dispatch uses the fully-qualified ID — this does not affect ledger presence or the never-hide convention. Discovered **external** reviewers (e.g. `code-reviewer`, `dragon-test-reviewer`) dispatch by their own discovered name, **never** prefixed with `dev-workflow:`.
+**Built-in vs external dispatch:** built-in plugin reviewers use `subagent_type: dev-workflow:<name>` (e.g. `dev-workflow:security-reviewer`). The selection ledger shows bare display names for readability; the dispatch uses the fully-qualified ID — this does not affect ledger presence or the never-hide convention. Discovered **external** reviewers (e.g. `code-reviewer`, `e2e-test-reviewer`) dispatch by their own discovered name, **never** prefixed with `dev-workflow:`.
 
 ## Dispatch instructions — apply to ALL templates
 


### PR DESCRIPTION
**Risk:** medium — size only (818 lines / 6 files); no sensitive paths, no breaking surface

## Impact

A create ship used to print `✓ <title>` and the PR URL and nothing else, so a ship-time
`/ba-compound` capture offer that never fired was byte-identical to one that correctly stayed
silent — the four trace lines meant to witness a skip were printed by the very prose being
skipped. Every create ship that reaches the output step now prints a third line,
`capture: <value>`, drawn from a closed six-value set, so a skip degrades to a visible
two-of-three-line receipt instead of vanishing. The mechanism was chosen by a four-condition
fixture comparison after the original two-way decision rule turned out to be unsatisfiable as
written.

## Motivation

Step 5f was specified as a required terminal step of Step 5, and routinely did not run. Its
observability story was circular: each silent path was supposed to leave a one-line reasoned
trace, but every one of those lines lived inside 5f — so the failure mode the traces existed to
catch was exactly the one they could not witness.

Resolving the predicate one step earlier fixes the witnessing problem without pretending to fix
the skip. What this buys is **co-location, not a guarantee** — a receipt printed by 5e prose is
still absent if that prose is skipped. The gain is that line 3 rides the URL line the model
reliably prints, so the predicted failure shifts from "an entire terminal step vanished with no
trace" to "printed 2 of 3 lines".

Resolves #85.

## Testing instructions

No automated coverage exists for prose command bodies, and a session executes the body it loaded
at start, so this cannot be dry-run by the session that wrote it. What was run:

- A 16-cell fixture A/B (4 routes x 4 conditions), one subagent per cell at the session model,
  scored on receipt presence, enum value, block contiguity, and confidence. The shipped arm
  scored 4/4 with zero forced improvisations; the two cheaper arms reached 4/4 only by
  improvising 9 times between them, or by emitting a duplicate contradictory trace. Full score
  table is in the first commit's body.
- `node scripts/selfcheck-invariants.mjs` (56/56) and `node scripts/check-invariants.mjs` (6/6,
  including `version-bump: 0.45.0 -> 0.46.0`).

To verify by hand: `claude --plugin-dir <this repo>` in a **fresh** session, then a real
`commit_push_create` ship. `--describe-only` never reaches the output step, so it cannot
exercise the receipt.

## Testing limitations

- **The A/B never reproduced the field defect.** 5f ran in all four baseline cells, so the run is
  evidence about receipt shape and emission and says nothing about whether co-location prevents
  the skip. A fresh-session ship is the first real test of that claim.
- **The receipt is a machine-boundary contract that no CI check pins.** The six enum literals are
  restated across five sites in the skill body plus two in `README.md`. `load-site-mirror` needs
  two byte-identical blocks and there is one emitter, so it does not apply. A canonical-site
  pointer in 5e is the only mitigation; any future enum change pays the seven-site tax again.
- **A literal grep is a false-green here.** While building one A/B arm, a sweep asserted the
  retired token absent and passed green while the file still read "the four `5f:` trace lines" —
  an abbreviated ninth site the full-token grep could not match. A subagent caught it, not the
  check.
- **Weight did not drop.** 5f shrank by 84 lines but 5e grew by 88, so the file is +4 net. This is
  a relocation, not a reduction.

**Proof:** _pending — add tests / QA notes / screenshots before merge_

## Alternatives considered

- **One sentence stating the receipt contract, nothing structural** (2 lines). Produced the line
  on every route, but left the four retired trace sites live, so two routes emitted the new line
  *and* the old contradictory one — one of them in the wrong order.
- **That sentence plus deleting every retired-token site** (27 lines, no resolver). Scored the
  same 4/4 as the shipped arm and was rejected on robustness rather than output: it reached the
  right answer *against* its own code sketch on the malformed-URL route, never names the offer
  path's enum value, and leaves `unavailable` assigned by no branch.
