### PR TITLE
chore: U9 scratch diff for the tracker-unconfigured negative control

### DIFF
--- a/U9-SCRATCH.md
+++ b/U9-SCRATCH.md
@@ -1,0 +1,3 @@
+# U9 scratch (run 2)
+
+Temporary file for the ship-time write-back negative control. Delete after.


### PR DESCRIPTION
**Risk:** low — single new markdown file, no runtime surface

Adds a throwaway scratch file so the ship-time write-back seam has a real diff and a non-empty deviation trailer to exercise the tracker-unconfigured path. Delete once the control run is done.

**Proof:** _pending — add tests / QA notes / screenshots before merge_
