### PR TITLE
chore: exercise the ship-time ticket write-back against a live issue

### DIFF
--- a/U9-SCRATCH.md
+++ b/U9-SCRATCH.md
@@ -1,0 +1,3 @@
+# U9 scratch
+
+Temporary file for the ship-time write-back live verification. Delete after.


### PR DESCRIPTION
**Risk:** low — adds one throwaway root-level markdown file; no runtime surface

Nothing in the plugin behaves differently. This branch exists only to drive one live `/ba-propose` run so the ship-time ticket write-back can be observed against a real issue — the receipt's `ticket:` line is the artifact here, not the diff. Delete the file and close the scratch issue once recorded.

**Proof:** _pending — add tests / QA notes / screenshots before merge_
